### PR TITLE
Harden media loading and state restoration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ music_playlist_libretro.dylib
 music_playlist_libretro.dll
 music_playlist_libretro.so
 localscripts/
+__pycache__/
+*.pyc
 
 # clang --analyze artifacts
 *.plist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,10 +33,11 @@ UltiMedia is a LibRetro audio player and music visualizer that runs as a core pl
 | `config.c` | LibRetro core options (declare + read) |
 | `layout.c` | Responsive UI layout computation |
 | `stb_vorbis_compat.h` | Shared Vorbis declarations used by `audio.c` and `metadata.c` |
+| `path_io.h` | UTF-8-aware file opening, including wide Windows paths |
 | `*.h` | Module interfaces; `core_debug.h` exposes state accessors for the test harness, `core_log.h` the shared diagnostic logger |
 
 **Tests & contributor tooling**
-- `tests/run_tests.py` — generates WAV/`.m3u` fixtures, compiles the native harness, runs it
+- `tests/run_tests.py` — generates audio/artwork/playlist fixtures, compiles the native harness, runs it
 - `tests/core_harness.c` — native LibRetro harness for playback/state/navigation checks
 - `tests/SMOKE_CHECKLIST.md` — manual frontend verification checklist
 - `scripts/setup-windows.ps1` / `test-windows.ps1` / `build-windows.ps1` — Windows (MSYS2 UCRT64) wrappers; `windows-common.ps1` holds shared helpers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ All source lives in `src/`, split by responsibility:
 | `image_codecs.c` | Third-party image decoder implementation (`stb_image`) |
 | `config.c` | LibRetro core options |
 | `layout.c` | Responsive UI layout computation |
+| `path_io.h` | UTF-8-aware file opening, including wide Windows paths |
 
 Tests live in `tests/`, and the Windows contributor helpers in `scripts/`.
 
@@ -63,7 +64,7 @@ curl -sL -o deps/stb_vorbis.c https://raw.githubusercontent.com/nothings/stb/mas
 python3 tests/run_tests.py
 ```
 
-`run_tests.py` generates temporary WAV and `.m3u` fixtures, compiles the native test harness, and exercises playback, navigation, shuffle, reset, and save-state behavior. It uses `cc` by default; override with `CC=/path/to/compiler`.
+`run_tests.py` generates temporary audio, artwork, and playlist fixtures, compiles the native test harness, and exercises playback, Unicode navigation, seeking, failure handling, shuffle, reset, and save-state behavior. It uses `cc` by default; override with `CC=/path/to/compiler` or add instrumentation through `CFLAGS`.
 
 > The distributable artifact is a Windows DLL, so the build command below targets MSYS2. On macOS/Linux the test harness is the primary local validation path — it compiles and links every `src/` module, so a clean run means the code at least builds across the codebase.
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ Run the native test harness locally with:
 python3 tests/run_tests.py
 ```
 
-This command generates temporary WAV and `.m3u` fixtures at runtime, compiles a native harness, and exercises playback, playlist navigation, shuffle, reset, and save-state behavior.
+This command generates temporary audio, artwork, and playlist fixtures at runtime, compiles a native harness, and exercises playback, UTF-8/UTF-16 playlist navigation, seeking, bad-track handling, artwork scaling, shuffle, reset, and save-state behavior.
+
+Set `CFLAGS` to add compiler instrumentation or diagnostics to the harness build, for example `CFLAGS="-fsanitize=address,undefined"` on a supported compiler.
 
 Windows local testing is supported through `MSYS2 UCRT64`. On macOS and Linux, the runner uses the system `cc` compiler by default.
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -1,4 +1,5 @@
 #include "audio.h"
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -6,6 +7,7 @@
 #include "dr_wav.h"
 #include "dr_flac.h"
 #include "stb_vorbis_compat.h"
+#include "path_io.h"
 
 #define AUDIO_STATE_SNAPSHOT_VERSION 1u
 
@@ -23,10 +25,66 @@ static int16_t resample_in_buf[SAMPLES_PER_FRAME * 8 * MAX_CHANNELS];
 static int16_t resample_cache[RESAMPLE_CACHE_FRAMES * MAX_CHANNELS];
 static int resample_cache_frames = 0;
 
-static int clamp_resample_cache_frames(int frames) {
-    if (frames < 0) return 0;
-    if (frames > RESAMPLE_CACHE_FRAMES) return RESAMPLE_CACHE_FRAMES;
-    return frames;
+static bool audio_snapshot_fields_valid(const AudioStateSnapshot *state) {
+    if (!state) return false;
+    if (state->current_type > AUDIO_FLAC) return false;
+    if (state->source_channels < 1 || state->source_channels > MAX_CHANNELS) return false;
+    if (state->resample_cache_frames < 0 || state->resample_cache_frames > RESAMPLE_CACHE_FRAMES)
+        return false;
+    if (!isfinite(state->resample_phase) || state->resample_phase < 0.0 || state->resample_phase >= 1.0)
+        return false;
+    if (state->cur_frame > state->total_frames) return false;
+
+    if ((AudioType)state->current_type == AUDIO_NONE) {
+        return state->source_rate == 0 &&
+               state->total_frames == 0 &&
+               state->cur_frame == 0 &&
+               state->resample_cache_frames == 0;
+    }
+
+    return state->source_rate > 0;
+}
+
+static bool audio_init_mp3_path(drmp3 *mp3, const char *path) {
+#ifdef _WIN32
+    wchar_t *wide = path_utf8_to_wide_alloc(path);
+    if (wide) {
+        bool opened = drmp3_init_file_w(mp3, wide, NULL) != 0;
+        free(wide);
+        if (opened) return true;
+    }
+#endif
+    return drmp3_init_file(mp3, path, NULL) != 0;
+}
+
+static bool audio_init_wav_path(drwav *wav, const char *path) {
+#ifdef _WIN32
+    wchar_t *wide = path_utf8_to_wide_alloc(path);
+    if (wide) {
+        bool opened = drwav_init_file_w(wav, wide, NULL) != 0;
+        free(wide);
+        if (opened) return true;
+    }
+#endif
+    return drwav_init_file(wav, path, NULL) != 0;
+}
+
+static drflac *audio_open_flac_path(const char *path) {
+#ifdef _WIN32
+    wchar_t *wide = path_utf8_to_wide_alloc(path);
+    if (wide) {
+        drflac *flac = drflac_open_file_w(wide, NULL);
+        free(wide);
+        if (flac) return flac;
+    }
+#endif
+    return drflac_open_file(path, NULL);
+}
+
+static stb_vorbis *audio_open_ogg_path(const char *path, int *error) {
+    FILE *file = path_fopen_read(path);
+    if (!file) return NULL;
+    return stb_vorbis_open_file(file, 1, error, NULL);
 }
 
 static void audio_reset_state_fields(void) {
@@ -165,7 +223,7 @@ bool audio_open_track(const char *path) {
 
     if (ext && strcasecmp_simple(ext, ".mp3") == 0) {
         decoder = malloc(sizeof(drmp3));
-        if (decoder && drmp3_init_file((drmp3*)decoder, path, NULL)) {
+        if (decoder && audio_init_mp3_path((drmp3*)decoder, path)) {
             current_type = AUDIO_MP3;
             source_rate = ((drmp3*)decoder)->sampleRate;
             source_channels = ((drmp3*)decoder)->channels;
@@ -174,7 +232,7 @@ bool audio_open_track(const char *path) {
         }
     } else if (ext && strcasecmp_simple(ext, ".ogg") == 0) {
         int err = 0;
-        stb_vorbis* ogg = stb_vorbis_open_filename(path, &err, NULL);
+        stb_vorbis* ogg = audio_open_ogg_path(path, &err);
         if (ogg) {
             current_type = AUDIO_OGG;
             decoder = ogg;
@@ -185,7 +243,7 @@ bool audio_open_track(const char *path) {
             load_success = true;
         }
     } else if (ext && strcasecmp_simple(ext, ".flac") == 0) {
-        drflac* flac = drflac_open_file(path, NULL);
+        drflac* flac = audio_open_flac_path(path);
         if (flac) {
             current_type = AUDIO_FLAC;
             decoder = flac;
@@ -196,7 +254,7 @@ bool audio_open_track(const char *path) {
         }
     } else {
         decoder = malloc(sizeof(drwav));
-        if (decoder && drwav_init_file((drwav*)decoder, path, NULL)) {
+        if (decoder && audio_init_wav_path((drwav*)decoder, path)) {
             current_type = AUDIO_WAV;
             source_rate = ((drwav*)decoder)->sampleRate;
             source_channels = ((drwav*)decoder)->channels;
@@ -215,8 +273,9 @@ bool audio_open_track(const char *path) {
         audio_close();
         return false;
     }
-    // A zero rate would stall the resampler (cur_frame would never advance).
-    if (source_rate == 0) {
+    // A zero rate stalls playback, while rates above the input-buffer ratio
+    // would force the resampler to skip source frames.
+    if (source_rate == 0 || source_rate > (uint32_t)(OUT_RATE * 8)) {
         audio_close();
         return false;
     }
@@ -244,29 +303,21 @@ void audio_capture_state(AudioStateSnapshot *state) {
 }
 
 bool audio_restore_state(const char *path, const AudioStateSnapshot *state) {
-    if (!state || state->version != AUDIO_STATE_SNAPSHOT_VERSION) return false;
-
-    int restored_cache_frames = clamp_resample_cache_frames(state->resample_cache_frames);
+    if (!state || state->version != AUDIO_STATE_SNAPSHOT_VERSION || !audio_snapshot_fields_valid(state))
+        return false;
 
     if ((AudioType)state->current_type == AUDIO_NONE) {
         audio_close();
-        source_rate = state->source_rate;
-        source_channels = state->source_channels;
-        total_frames = state->total_frames;
-        cur_frame = state->cur_frame;
-        resample_phase = state->resample_phase;
-        resample_cache_frames = restored_cache_frames;
-        memcpy(resample_cache, state->resample_cache, sizeof(resample_cache));
         return true;
     }
 
     if (!path || !audio_open_track(path)) return false;
     uint64_t resume_frame = state->cur_frame;
-    if ((uint64_t)restored_cache_frames > UINT64_MAX - resume_frame) {
+    if ((uint64_t)state->resample_cache_frames > UINT64_MAX - resume_frame) {
         audio_close();
         return false;
     }
-    resume_frame += (uint64_t)restored_cache_frames;
+    resume_frame += (uint64_t)state->resample_cache_frames;
     if (current_type != (AudioType)state->current_type ||
         source_rate != state->source_rate ||
         source_channels != state->source_channels ||
@@ -280,7 +331,7 @@ bool audio_restore_state(const char *path, const AudioStateSnapshot *state) {
     audio_seek(resume_frame);
     cur_frame = state->cur_frame;
     resample_phase = state->resample_phase;
-    resample_cache_frames = restored_cache_frames;
+    resample_cache_frames = state->resample_cache_frames;
     memset(resample_cache, 0, sizeof(resample_cache));
     memcpy(resample_cache, state->resample_cache, sizeof(resample_cache));
     return true;
@@ -288,6 +339,9 @@ bool audio_restore_state(const char *path, const AudioStateSnapshot *state) {
 
 void audio_seek(uint64_t frame) {
     cur_frame = frame;
+    resample_phase = 0.0;
+    resample_cache_frames = 0;
+    memset(resample_cache, 0, sizeof(resample_cache));
     if (current_type == AUDIO_MP3) drmp3_seek_to_pcm_frame((drmp3*)decoder, cur_frame);
     else if (current_type == AUDIO_WAV) drwav_seek_to_pcm_frame((drwav*)decoder, cur_frame);
     else if (current_type == AUDIO_OGG) stb_vorbis_seek((stb_vorbis*)decoder, cur_frame);
@@ -358,6 +412,7 @@ int audio_read_frame(int16_t *out_buf) {
 
     resample_phase = new_phase;
     cur_frame += (uint64_t)advance_frames;
+    if (total_frames > 0 && cur_frame > total_frames) cur_frame = total_frames;
 
     int overshoot = (int)total_available - (int)advance_frames;
     if (overshoot < 0) overshoot = 0;

--- a/src/core.c
+++ b/src/core.c
@@ -17,6 +17,7 @@
 #include "metadata.h"
 #include "visualizer.h"
 #include "core_log.h"
+#include "path_io.h"
 
 #define CORE_MAX_TRACKS 256
 #define CORE_MAX_PATH 1024
@@ -166,6 +167,12 @@ static void draw_rect_outline(int x, int y, int w, int h, uint16_t color) {
         draw_pixel(x, py, color);
         draw_pixel(x2, py, color);
     }
+}
+
+static int playback_progress_width(int width) {
+    if (width <= 0 || total_frames == 0 || cur_frame == 0) return 0;
+    if (cur_frame >= total_frames) return width;
+    return (int)(((double)cur_frame / (double)total_frames) * (double)width);
 }
 
 // Helper function for case-insensitive string comparison
@@ -786,15 +793,15 @@ void retro_run(void) {
             // Decoder seeks are costly (MP3 backward seeks re-decode from the
             // start of the file), so a held button repeats at 10 Hz, not 60.
             seek_repeat_cooldown = 6;
-            int seek_speed = source_rate * 3;
+            uint64_t seek_speed = (uint64_t)source_rate * 3u;
             if (seek_fwd) {
-                uint64_t next = cur_frame + (uint64_t)seek_speed;
+                uint64_t next = cur_frame + seek_speed;
                 if (next < cur_frame) next = cur_frame; // overflow guard
                 if (total_frames > 0 && next >= total_frames) next = total_frames - 1;
                 audio_seek(next);
                 ff_rw_icon_timer = 15; ff_rw_dir = 1;
             } else {
-                uint64_t next = (cur_frame < (uint64_t)seek_speed) ? 0 : cur_frame - (uint64_t)seek_speed;
+                uint64_t next = (cur_frame < seek_speed) ? 0 : cur_frame - seek_speed;
                 audio_seek(next);
                 ff_rw_icon_timer = 15; ff_rw_dir = -1;
             }
@@ -865,9 +872,9 @@ void retro_run(void) {
         }
 
         if (cfg.show_bar && total_frames > 0 && layout.bar.w > 0) {
-            float p = (float)cur_frame / total_frames;
+            int filled_w = playback_progress_width(layout.bar.w);
             for (int w = 0; w < layout.bar.w; w++) draw_pixel(layout.bar.x + w, layout.bar.y, cfg.bg_rgb | 0x18C3);
-            for (int w = 0; w < (int)(p * layout.bar.w); w++) draw_pixel(layout.bar.x + w, layout.bar.y, cfg.fg_rgb);
+            for (int w = 0; w < filled_w; w++) draw_pixel(layout.bar.x + w, layout.bar.y, cfg.fg_rgb);
         }
 
         if (cfg.show_tim && layout.time.w > 0) {
@@ -914,9 +921,9 @@ void retro_run(void) {
             viz_draw();
         }
         if (cfg.show_bar && total_frames > 0) {
-            float p = (float)cur_frame / (float)total_frames;
+            int filled_w = playback_progress_width(200);
             for (int w = 0; w < 200; w++) draw_pixel(60 + w, cfg.bar_y, cfg.bg_rgb | 0x18C3);
-            for (int w = 0; w < (int)(p * 200); w++) draw_pixel(60 + w, cfg.bar_y, cfg.fg_rgb);
+            for (int w = 0; w < filled_w; w++) draw_pixel(60 + w, cfg.bar_y, cfg.fg_rgb);
         }
         if (cfg.show_tim) {
             int sec = source_rate ? (int)(cur_frame / source_rate) : 0;
@@ -947,6 +954,8 @@ void retro_set_environment(retro_environment_t cb) {
 bool retro_load_game(const struct retro_game_info *g) {
     if (!g || !g->path) return false;
 
+    audio_close();
+    metadata_free_art();
     free_tracks();
     current_idx = 0;
     m3u_base_path[0] = '\0';
@@ -958,7 +967,7 @@ bool retro_load_game(const struct retro_game_info *g) {
     if (ext && strcasecmp_simple(ext, ".m3u") == 0) {
         core_log(RETRO_LOG_DEBUG, "[MusicCore] Attempting to open M3U: %s\n", g->path);
 
-        FILE *f = fopen(g->path, "rb");
+        FILE *f = path_fopen_read(g->path);
         if (!f) {
             core_log(RETRO_LOG_ERROR, "[MusicCore] Failed to open M3U at %s\n", g->path);
             return false;
@@ -1050,18 +1059,33 @@ bool retro_load_game(const struct retro_game_info *g) {
         track_count++;
     }
 
-    if (track_count == 0) return false;
+    if (track_count == 0) {
+        m3u_base_path[0] = '\0';
+        return false;
+    }
 
     start_shuffle_cycle(generate_shuffle_seed());
     apply_config_update();
     if (cfg.responsive)
         layout_compute();
 
-    if (!open_track(0)) {
+    bool opened = open_track(0);
+    if (!opened) {
         // Skip past unreadable leading tracks so the playlist still starts.
         for (int i = 1; i < track_count; i++) {
-            if (open_track(i)) break;
+            if (open_track(i)) {
+                opened = true;
+                break;
+            }
         }
+    }
+    if (!opened) {
+        audio_close();
+        metadata_free_art();
+        free_tracks();
+        current_idx = 0;
+        m3u_base_path[0] = '\0';
+        return false;
     }
     return true;
 }
@@ -1087,8 +1111,8 @@ void retro_set_input_poll(retro_input_poll_t cb) { input_poll_cb = cb; }
 void retro_set_input_state(retro_input_state_t cb) { input_state_cb = cb; }
 unsigned retro_api_version(void) { return RETRO_API_VERSION; }
 void retro_get_system_info(struct retro_system_info *i) {
-    i->library_name = "UltiMedia UGC";
-    i->library_version = "17.0";
+    i->library_name = "Music Playlist Core";
+    i->library_version = "1.0";
     i->valid_extensions = "mp3|wav|m3u|ogg|flac";
     i->need_fullpath = true;
 }
@@ -1235,9 +1259,13 @@ bool retro_unserialize(const void *d, size_t s) {
     metadata_load(tracks[current_idx], m3u_base_path, cfg.track_text_mode);
     is_paused = state->is_paused != 0;
     is_shuffle = state->is_shuffle != 0;
+    int min_scroll_x = -((int)strlen(display_str) * 8);
     scroll_x = state->scroll_x;
+    if (scroll_x < min_scroll_x || scroll_x > FB_WIDTH) scroll_x = FB_WIDTH;
     ff_rw_icon_timer = state->ff_rw_icon_timer;
-    ff_rw_dir = state->ff_rw_dir;
+    if (ff_rw_icon_timer < 0) ff_rw_icon_timer = 0;
+    if (ff_rw_icon_timer > 15) ff_rw_icon_timer = 15;
+    ff_rw_dir = (state->ff_rw_dir > 0) ? 1 : ((state->ff_rw_dir < 0) ? -1 : 0);
     shuffle_seed = sanitize_seed(state->shuffle_seed ? state->shuffle_seed : current_content_hash());
     shuffle_state = sanitize_seed(state->shuffle_state ? state->shuffle_state : shuffle_seed);
     shuffle_count = (int)state->shuffle_count;

--- a/src/image_codecs.c
+++ b/src/image_codecs.c
@@ -1,2 +1,4 @@
+#define STBI_MAX_DIMENSIONS 4096
+#define STBI_WINDOWS_UTF8
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -6,10 +6,14 @@
 #include "dr_flac.h"
 #include "stb_image.h"
 #include "stb_vorbis_compat.h"
+#include "path_io.h"
 
 uint16_t *art_buffer = NULL;
 int art_w_src = 0, art_h_src = 0;
 char display_str[256];
+
+#define ART_MAX_DIMENSION 4096
+#define ART_STORED_MAX_DIMENSION 120
 
 typedef struct {
     char *artist;
@@ -17,6 +21,57 @@ typedef struct {
     char *album;
     int maxlen;
 } FlacMetaContext;
+
+static int art_dimensions_valid(int width, int height) {
+    return width > 0 && height > 0 &&
+           width <= ART_MAX_DIMENSION && height <= ART_MAX_DIMENSION;
+}
+
+static unsigned char *load_art_file(const char *path, int *width, int *height) {
+    int components = 0;
+    if (!path || !width || !height) return NULL;
+    if (!stbi_info(path, width, height, &components) || !art_dimensions_valid(*width, *height))
+        return NULL;
+    return stbi_load(path, width, height, NULL, 3);
+}
+
+static unsigned char *load_art_memory(const unsigned char *data, size_t size, int *width, int *height) {
+    int components = 0;
+    if (!data || size == 0 || size > INT32_MAX || !width || !height) return NULL;
+    if (!stbi_info_from_memory(data, (int)size, width, height, &components) ||
+        !art_dimensions_valid(*width, *height))
+        return NULL;
+    return stbi_load_from_memory(data, (int)size, width, height, NULL, 3);
+}
+
+static void store_art_rgb565(const unsigned char *img_data, int source_w, int source_h) {
+    if (!img_data || !art_dimensions_valid(source_w, source_h)) return;
+
+    int stored_w = source_w;
+    int stored_h = source_h;
+    if (stored_w > ART_STORED_MAX_DIMENSION) stored_w = ART_STORED_MAX_DIMENSION;
+    if (stored_h > ART_STORED_MAX_DIMENSION) stored_h = ART_STORED_MAX_DIMENSION;
+
+    size_t pixel_count = (size_t)stored_w * (size_t)stored_h;
+    uint16_t *stored = malloc(pixel_count * sizeof(*stored));
+    if (!stored) return;
+
+    for (int y = 0; y < stored_h; y++) {
+        int source_y = (int)(((size_t)y * (size_t)source_h) / (size_t)stored_h);
+        for (int x = 0; x < stored_w; x++) {
+            int source_x = (int)(((size_t)x * (size_t)source_w) / (size_t)stored_w);
+            const unsigned char *pixel = img_data +
+                (((size_t)source_y * (size_t)source_w + (size_t)source_x) * 3u);
+            uint8_t r = pixel[0], g = pixel[1], b = pixel[2];
+            stored[(size_t)y * (size_t)stored_w + (size_t)x] =
+                (uint16_t)(((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3));
+        }
+    }
+
+    art_buffer = stored;
+    art_w_src = stored_w;
+    art_h_src = stored_h;
+}
 
 static int strcasecmp_simple(const char *s1, const char *s2) {
     while (*s1 && *s2) {
@@ -94,7 +149,9 @@ static void maybe_store_tag(const char *entry, char *artist, char *title, char *
 
 static int parse_ogg_vorbis_tags(const char *path, char *artist, char *title, char *album, int maxlen) {
     int err = 0;
-    stb_vorbis *ogg = stb_vorbis_open_filename(path, &err, NULL);
+    FILE *file = path_fopen_read(path);
+    if (!file) return 0;
+    stb_vorbis *ogg = stb_vorbis_open_file(file, 1, &err, NULL);
     if (!ogg) return 0;
 
     stb_vorbis_comment comments = stb_vorbis_get_comment(ogg);
@@ -136,14 +193,22 @@ static int parse_flac_vorbis_tags(const char *path, char *artist, char *title, c
     ctx.album = album;
     ctx.maxlen = maxlen;
 
-    drflac *flac = drflac_open_file_with_metadata(path, flac_meta_proc, &ctx, NULL);
+    drflac *flac = NULL;
+#ifdef _WIN32
+    wchar_t *wide = path_utf8_to_wide_alloc(path);
+    if (wide) {
+        flac = drflac_open_file_with_metadata_w(wide, flac_meta_proc, &ctx, NULL);
+        free(wide);
+    }
+#endif
+    if (!flac) flac = drflac_open_file_with_metadata(path, flac_meta_proc, &ctx, NULL);
     if (!flac) return 0;
     drflac_close(flac);
     return (title[0] || artist[0]) ? 1 : 0;
 }
 
 int parse_id3v2(const char* path, char* artist, char* title, char* album, int maxlen) {
-    FILE* f = fopen(path, "rb");
+    FILE* f = path_fopen_read(path);
     if (!f) return 0;
 
     // 1. Read and validate header
@@ -259,6 +324,8 @@ void metadata_free_art(void) {
         free(art_buffer);
         art_buffer = NULL;
     }
+    art_w_src = 0;
+    art_h_src = 0;
 }
 
 static void metadata_build_display(const char *track_path, TrackTextMode track_text_mode, char *album_out, size_t album_out_size) {
@@ -276,7 +343,7 @@ static void metadata_build_display(const char *track_path, TrackTextMode track_t
 
         if (!found && ext && strcasecmp_simple(ext, ".mp3") == 0) {
             // Fall back to ID3v1 for MP3s.
-            FILE* f = fopen(track_path, "rb");
+            FILE* f = path_fopen_read(track_path);
             if (f) {
                 if (fseek(f, -128, SEEK_END) == 0) {
                     char tag[3];
@@ -337,6 +404,7 @@ void metadata_load(const char *track_path, const char *m3u_base_path, TrackTextM
     // --- Load Artwork (The 5 Location Search) ---
     metadata_free_art();
     unsigned char* img_data = NULL;
+    int img_w = 0, img_h = 0;
     char path_buf[1024];
     const char* exts[] = { ".jpg", ".jpeg", ".png", ".bmp" };
 
@@ -345,13 +413,17 @@ void metadata_load(const char *track_path, const char *m3u_base_path, TrackTextM
     const char* last_s = strrchr(track_path, '/');
     if (!last_s) last_s = strrchr(track_path, '\\');
     if (last_s) {
-        size_t dir_len = last_s - track_path;
-        strncpy(music_dir, track_path, dir_len);
+        size_t dir_len = (size_t)(last_s - track_path);
+        if (dir_len >= sizeof(music_dir)) dir_len = sizeof(music_dir) - 1;
+        memcpy(music_dir, track_path, dir_len);
         music_dir[dir_len] = '\0';
         const char* p_slash = strrchr(music_dir, '/');
         if (!p_slash) p_slash = strrchr(music_dir, '\\');
-        strncpy(parent_name, p_slash ? p_slash + 1 : music_dir, sizeof(parent_name) - 1);
-        parent_name[sizeof(parent_name) - 1] = '\0';
+        const char *parent = p_slash ? p_slash + 1 : music_dir;
+        size_t parent_len = strlen(parent);
+        if (parent_len >= sizeof(parent_name)) parent_len = sizeof(parent_name) - 1;
+        memcpy(parent_name, parent, parent_len);
+        parent_name[parent_len] = '\0';
     }
 
     // B. Main Search Loop
@@ -365,20 +437,24 @@ void metadata_load(const char *track_path, const char *m3u_base_path, TrackTextM
         } else {
             snprintf(path_buf, sizeof(path_buf), "%s%s", track_path, exts[i]);
         }
-        img_data = stbi_load(path_buf, &art_w_src, &art_h_src, NULL, 3);
+        img_data = load_art_file(path_buf, &img_w, &img_h);
         if (img_data) break;
 
         if (music_dir[0]) {
             // 2. Name of Parent Folder (e.g., C:/Music/AlbumName/AlbumName.jpg)
-            snprintf(path_buf, sizeof(path_buf), "%s/%s%s", music_dir, parent_name, exts[i]);
-            img_data = stbi_load(path_buf, &art_w_src, &art_h_src, NULL, 3);
-            if (img_data) break;
+            int written = snprintf(path_buf, sizeof(path_buf), "%s/%s%s", music_dir, parent_name, exts[i]);
+            if (written > 0 && written < (int)sizeof(path_buf)) {
+                img_data = load_art_file(path_buf, &img_w, &img_h);
+                if (img_data) break;
+            }
 
             // 3. Album Name from Metadata (e.g., C:/Music/AlbumName/MetadataAlbum.jpg)
             if (cur_album[0]) {
-                snprintf(path_buf, sizeof(path_buf), "%s/%s%s", music_dir, cur_album, exts[i]);
-                img_data = stbi_load(path_buf, &art_w_src, &art_h_src, NULL, 3);
-                if (img_data) break;
+                written = snprintf(path_buf, sizeof(path_buf), "%s/%s%s", music_dir, cur_album, exts[i]);
+                if (written > 0 && written < (int)sizeof(path_buf)) {
+                    img_data = load_art_file(path_buf, &img_w, &img_h);
+                    if (img_data) break;
+                }
             }
         }
 
@@ -392,14 +468,14 @@ void metadata_load(const char *track_path, const char *m3u_base_path, TrackTextM
             } else {
                 snprintf(path_buf, sizeof(path_buf), "%s%s", m3u_base_path, exts[i]);
             }
-            img_data = stbi_load(path_buf, &art_w_src, &art_h_src, NULL, 3);
+            img_data = load_art_file(path_buf, &img_w, &img_h);
             if (img_data) break;
         }
     }
 
     // 5. Files Metadata (Aggressive APIC/PIC Scan)
     if (!img_data) {
-        FILE* f_art = fopen(track_path, "rb");
+        FILE* f_art = path_fopen_read(track_path);
         if (f_art) {
             // Scan 1MB: embedded art is often large and offset deep in the header
             size_t scan_size = 1024 * 1024;
@@ -411,12 +487,12 @@ void metadata_load(const char *track_path, const char *m3u_base_path, TrackTextM
                 for (size_t i = 0; i + 10 < bytes_read; i++) {
                     // Check for JPEG (FF D8 FF)
                     if (head[i] == 0xFF && head[i+1] == 0xD8 && head[i+2] == 0xFF) {
-                        img_data = stbi_load_from_memory(head + i, (int)(bytes_read - i), &art_w_src, &art_h_src, NULL, 3);
+                        img_data = load_art_memory(head + i, bytes_read - i, &img_w, &img_h);
                         if (img_data) break;
                     }
                     // Check for PNG (89 50 4E 47)
                     if (head[i] == 0x89 && head[i+1] == 0x50 && head[i+2] == 0x4E && head[i+3] == 0x47) {
-                        img_data = stbi_load_from_memory(head + i, (int)(bytes_read - i), &art_w_src, &art_h_src, NULL, 3);
+                        img_data = load_art_memory(head + i, bytes_read - i, &img_w, &img_h);
                         if (img_data) break;
                     }
                 }
@@ -428,18 +504,7 @@ void metadata_load(const char *track_path, const char *m3u_base_path, TrackTextM
 
     // Prepare for Rendering (RGB565)
     if (img_data) {
-        if (art_w_src > 0 && art_h_src > 0 && art_w_src <= 4096 && art_h_src <= 4096) {
-            size_t pixel_count = (size_t)art_w_src * (size_t)art_h_src;
-            size_t art_size = pixel_count * sizeof(*art_buffer);
-            art_buffer = malloc(art_size);
-            if (art_buffer) {
-                for (size_t i = 0; i < pixel_count; i++) {
-                    const unsigned char *pixel = img_data + (i * 3);
-                    uint8_t r = pixel[0], g = pixel[1], b = pixel[2];
-                    art_buffer[i] = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
-                }
-            }
-        }
+        store_art_rgb565(img_data, img_w, img_h);
         stbi_image_free(img_data);
     }
 }

--- a/src/path_io.h
+++ b/src/path_io.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <wchar.h>
+
+static wchar_t *path_utf8_to_wide_alloc(const char *path) {
+    if (!path) return NULL;
+
+    int length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, NULL, 0);
+    if (length <= 0) return NULL;
+
+    wchar_t *wide = malloc((size_t)length * sizeof(*wide));
+    if (!wide) return NULL;
+    if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, wide, length) <= 0) {
+        free(wide);
+        return NULL;
+    }
+    return wide;
+}
+#endif
+
+static FILE *path_fopen_read(const char *path) {
+#ifdef _WIN32
+    wchar_t *wide = path_utf8_to_wide_alloc(path);
+    if (wide) {
+        FILE *file = _wfopen(wide, L"rb");
+        free(wide);
+        if (file) return file;
+    }
+#endif
+    return fopen(path, "rb");
+}

--- a/src/stb_vorbis_compat.h
+++ b/src/stb_vorbis_compat.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdio.h>
+
 typedef struct
 {
     char *alloc_buffer;
@@ -31,6 +33,7 @@ extern stb_vorbis_info stb_vorbis_get_info(stb_vorbis *f);
 extern stb_vorbis_comment stb_vorbis_get_comment(stb_vorbis *f);
 extern void stb_vorbis_close(stb_vorbis *f);
 extern stb_vorbis *stb_vorbis_open_filename(const char *filename, int *error, const stb_vorbis_alloc *alloc_buffer);
+extern stb_vorbis *stb_vorbis_open_file(FILE *file, int close_handle_on_close, int *error, const stb_vorbis_alloc *alloc_buffer);
 extern int stb_vorbis_seek(stb_vorbis *f, unsigned int sample_number);
 extern unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f);
 extern int stb_vorbis_get_samples_short_interleaved(stb_vorbis *f, int channels, short *buffer, int num_shorts);

--- a/src/video.c
+++ b/src/video.c
@@ -28,7 +28,7 @@ void video_clear(uint16_t bg_color) {
 }
 
 void draw_pixel(int x, int y, uint16_t color) {
-    if (x >= 0 && x < FB_WIDTH && y >= 0 && y < FB_HEIGHT) {
+    if (framebuffer && x >= 0 && x < FB_WIDTH && y >= 0 && y < FB_HEIGHT) {
         framebuffer[y * FB_WIDTH + x] = color;
     }
 }

--- a/tests/core_harness.c
+++ b/tests/core_harness.c
@@ -16,6 +16,7 @@
 #define MAX_ENV_OPTIONS 32
 #define MAX_JOYPAD_IDS 32
 #define MAX_PATH_LEN 1024
+#define TEST_CORE_MAX_TRACKS 256
 
 typedef struct {
     const char *key;
@@ -32,6 +33,33 @@ typedef struct {
     const char *name;
     TestFn fn;
 } TestCase;
+
+typedef struct {
+    uint32_t magic;
+    uint32_t version;
+    uint32_t content_hash;
+    uint32_t track_count;
+    int32_t current_idx;
+    int32_t viz_mode;
+    int32_t scroll_x;
+    int32_t legacy_debounce;
+    int32_t ff_rw_icon_timer;
+    int32_t ff_rw_dir;
+    uint8_t is_paused;
+    uint8_t is_shuffle;
+    uint8_t reserved[2];
+    uint32_t shuffle_seed;
+    uint32_t shuffle_state;
+    uint32_t shuffle_count;
+    uint32_t shuffle_pos;
+    uint32_t shuffle_history_count;
+    uint32_t shuffle_history_pos;
+    AudioStateSnapshot audio;
+    int32_t shuffle_order[TEST_CORE_MAX_TRACKS];
+    int32_t shuffle_history[TEST_CORE_MAX_TRACKS];
+    uint32_t m3u_base_path_len;
+    uint32_t track_path_lens[TEST_CORE_MAX_TRACKS];
+} TestCoreStateSnapshot;
 
 static EnvOption g_env_options[MAX_ENV_OPTIONS];
 static int g_env_option_count = 0;
@@ -53,6 +81,7 @@ extern void retro_set_audio_sample_batch(retro_audio_sample_batch_t cb);
 extern void retro_set_video_refresh(retro_video_refresh_t cb);
 extern void retro_set_input_poll(retro_input_poll_t cb);
 extern void retro_set_input_state(retro_input_state_t cb);
+extern void retro_get_system_info(struct retro_system_info *info);
 
 static void clear_env_options(void) {
     g_env_option_count = 0;
@@ -259,6 +288,165 @@ static bool test_playlist_navigation(TestContext *ctx) {
     if (!require_true(core_debug_get_current_index() == 3, "playlist_navigation: expected wrap to current index 3"))
         return false;
     if (!require_true(current_track_is("track_d.wav"), "playlist_navigation: expected track_d.wav after wrap"))
+        return false;
+    return true;
+}
+
+static bool test_utf16_unicode_playlists(TestContext *ctx) {
+    const char *playlist_names[] = { "playlist_utf16le.m3u", "playlist_utf16be.m3u" };
+    char path[MAX_PATH_LEN];
+
+    for (size_t i = 0; i < sizeof(playlist_names) / sizeof(playlist_names[0]); i++) {
+        prepare_test();
+        build_path(path, sizeof(path), ctx->fixtures_dir, playlist_names[i]);
+
+        if (!load_game_path(path))
+            return failf("utf16_unicode_playlists: failed to load %s", path);
+        if (!require_true(core_debug_get_track_count() == 1,
+                          "utf16_unicode_playlists: expected one track for %s", playlist_names[i]))
+            return false;
+        if (!require_true(current_track_is("unicode_音.wav"),
+                          "utf16_unicode_playlists: Unicode track did not open for %s", playlist_names[i]))
+            return false;
+
+        run_frames(2);
+        if (!require_true(cur_frame > 0,
+                          "utf16_unicode_playlists: playback did not advance for %s", playlist_names[i]))
+            return false;
+    }
+
+    return true;
+}
+
+static bool test_bad_track_skipping(TestContext *ctx) {
+    char path[MAX_PATH_LEN];
+    prepare_test();
+    build_path(path, sizeof(path), ctx->fixtures_dir, "playlist_missing_middle.m3u");
+
+    if (!load_game_path(path))
+        return failf("bad_track_skipping: failed to load %s", path);
+    if (!require_true(current_track_is("track_a.wav"), "bad_track_skipping: expected track_a.wav first"))
+        return false;
+
+    tap_button(RETRO_DEVICE_ID_JOYPAD_R);
+    if (!require_true(core_debug_get_current_index() == 2,
+                      "bad_track_skipping: expected missing index 1 to be skipped"))
+        return false;
+    if (!require_true(current_track_is("track_b.wav"), "bad_track_skipping: expected track_b.wav after skip"))
+        return false;
+
+    prepare_test();
+    build_path(path, sizeof(path), ctx->fixtures_dir, "playlist_all_bad.m3u");
+    if (!require_true(!load_game_path(path), "bad_track_skipping: all-bad playlist was accepted"))
+        return false;
+    if (!require_true(core_debug_get_track_count() == 0 && decoder == NULL,
+                      "bad_track_skipping: failed load retained playback state"))
+        return false;
+    return true;
+}
+
+static bool test_unsupported_sample_rate_is_rejected(TestContext *ctx) {
+    char path[MAX_PATH_LEN];
+    prepare_test();
+    build_path(path, sizeof(path), ctx->fixtures_dir, "unsupported_rate.wav");
+
+    if (!require_true(!load_game_path(path),
+                      "unsupported_sample_rate_is_rejected: 768 kHz source was accepted"))
+        return false;
+    if (!require_true(core_debug_get_track_count() == 0 && decoder == NULL,
+                      "unsupported_sample_rate_is_rejected: failed load retained state"))
+        return false;
+    return true;
+}
+
+static bool test_seek_tap_and_repeat(TestContext *ctx) {
+    char path[MAX_PATH_LEN];
+    uint64_t before_seek;
+    uint64_t after_first_seek;
+    uint64_t before_repeat;
+    uint64_t before_backward;
+
+    prepare_test();
+    build_path(path, sizeof(path), ctx->fixtures_dir, "seek_long.wav");
+    if (!load_game_path(path))
+        return failf("seek_tap_and_repeat: failed to load %s", path);
+
+    run_frames(5);
+    before_seek = cur_frame;
+    g_pressed[RETRO_DEVICE_ID_JOYPAD_RIGHT] = true;
+    retro_run();
+    after_first_seek = cur_frame;
+    if (!require_true(after_first_seek > before_seek + (uint64_t)source_rate * 2u,
+                      "seek_tap_and_repeat: forward tap did not seek about three seconds"))
+        return false;
+
+    before_repeat = cur_frame;
+    run_frames(5);
+    if (!require_true(cur_frame < before_repeat + (uint64_t)source_rate,
+                      "seek_tap_and_repeat: held seek repeated before cooldown expired"))
+        return false;
+    retro_run();
+    if (!require_true(cur_frame > before_repeat + (uint64_t)source_rate * 2u,
+                      "seek_tap_and_repeat: held seek did not repeat after cooldown"))
+        return false;
+
+    g_pressed[RETRO_DEVICE_ID_JOYPAD_RIGHT] = false;
+    retro_run();
+    before_backward = cur_frame;
+    g_pressed[RETRO_DEVICE_ID_JOYPAD_LEFT] = true;
+    retro_run();
+    g_pressed[RETRO_DEVICE_ID_JOYPAD_LEFT] = false;
+    if (!require_true(cur_frame + (uint64_t)source_rate * 2u < before_backward,
+                      "seek_tap_and_repeat: backward tap did not seek about three seconds"))
+        return false;
+    return true;
+}
+
+static bool test_short_track_position_is_bounded(TestContext *ctx) {
+    char path[MAX_PATH_LEN];
+    prepare_test();
+    build_path(path, sizeof(path), ctx->fixtures_dir, "short.wav");
+
+    if (!load_game_path(path))
+        return failf("short_track_position_is_bounded: failed to load %s", path);
+    if (!require_true(total_frames > 0 && total_frames < SAMPLES_PER_FRAME,
+                      "short_track_position_is_bounded: fixture was not shorter than one output frame"))
+        return false;
+
+    retro_run();
+    if (!require_true(cur_frame <= total_frames,
+                      "short_track_position_is_bounded: cur_frame exceeded total_frames"))
+        return false;
+    return true;
+}
+
+static bool test_artwork_is_downscaled(TestContext *ctx) {
+    char path[MAX_PATH_LEN];
+    prepare_test();
+    build_path(path, sizeof(path), ctx->fixtures_dir, "art_track.wav");
+
+    if (!load_game_path(path))
+        return failf("artwork_is_downscaled: failed to load %s", path);
+    if (!require_true(art_buffer != NULL, "artwork_is_downscaled: expected sidecar artwork to load"))
+        return false;
+    if (!require_true(art_w_src == 120 && art_h_src == 120,
+                      "artwork_is_downscaled: expected 120x120 stored art, got %dx%d", art_w_src, art_h_src))
+        return false;
+    run_frames(2);
+    return true;
+}
+
+static bool test_core_identity_matches_info(TestContext *ctx) {
+    struct retro_system_info info;
+    (void)ctx;
+    memset(&info, 0, sizeof(info));
+    retro_get_system_info(&info);
+
+    if (!require_true(info.library_name && strcmp(info.library_name, "Music Playlist Core") == 0,
+                      "core_identity_matches_info: unexpected library name"))
+        return false;
+    if (!require_true(info.library_version && strcmp(info.library_version, "1.0") == 0,
+                      "core_identity_matches_info: unexpected library version"))
         return false;
     return true;
 }
@@ -629,6 +817,71 @@ done:
     return ok;
 }
 
+static bool test_malformed_save_states_are_rejected(TestContext *ctx) {
+    char path[MAX_PATH_LEN];
+    size_t state_size;
+    void *state_data = NULL;
+    TestCoreStateSnapshot *snapshot;
+    uint64_t before_frames;
+    uint32_t saved_magic;
+    uint32_t saved_audio_type;
+    double saved_phase;
+    bool ok = false;
+
+    prepare_test();
+    build_path(path, sizeof(path), ctx->fixtures_dir, "track_a.wav");
+    if (!load_game_path(path))
+        return failf("malformed_save_states: failed to load %s", path);
+    run_frames(4);
+
+    state_size = retro_serialize_size();
+    if (!require_true(state_size > sizeof(TestCoreStateSnapshot),
+                      "malformed_save_states: state was smaller than expected snapshot"))
+        return false;
+    state_data = malloc(state_size);
+    if (!state_data) return failf("malformed_save_states: failed to allocate %zu bytes", state_size);
+    if (!require_true(retro_serialize(state_data, state_size), "malformed_save_states: serialize failed"))
+        goto done;
+
+    snapshot = (TestCoreStateSnapshot*)state_data;
+    before_frames = cur_frame;
+
+    if (!require_true(!retro_unserialize(state_data, sizeof(TestCoreStateSnapshot) - 1),
+                      "malformed_save_states: truncated state was accepted"))
+        goto done;
+
+    saved_magic = snapshot->magic;
+    snapshot->magic ^= 0xFFFFFFFFu;
+    if (!require_true(!retro_unserialize(state_data, state_size),
+                      "malformed_save_states: corrupt magic was accepted"))
+        goto done;
+    snapshot->magic = saved_magic;
+
+    saved_audio_type = snapshot->audio.current_type;
+    snapshot->audio.current_type = AUDIO_NONE;
+    if (!require_true(!retro_unserialize(state_data, state_size),
+                      "malformed_save_states: inconsistent AUDIO_NONE state was accepted"))
+        goto done;
+    snapshot->audio.current_type = saved_audio_type;
+
+    saved_phase = snapshot->audio.resample_phase;
+    snapshot->audio.resample_phase = NAN;
+    if (!require_true(!retro_unserialize(state_data, state_size),
+                      "malformed_save_states: non-finite resampler phase was accepted"))
+        goto done;
+    snapshot->audio.resample_phase = saved_phase;
+
+    run_frames(2);
+    if (!require_true(cur_frame > before_frames,
+                      "malformed_save_states: playback did not remain usable after rejected states"))
+        goto done;
+
+    ok = true;
+done:
+    free(state_data);
+    return ok;
+}
+
 static bool test_config_layout_smoke(TestContext *ctx) {
     char path[MAX_PATH_LEN];
 
@@ -800,6 +1053,13 @@ static bool test_track_change_resets_fft_visualizer_state(TestContext *ctx) {
 static const TestCase kTests[] = {
     { "basic_load_play", test_basic_load_play },
     { "playlist_navigation", test_playlist_navigation },
+    { "utf16_unicode_playlists", test_utf16_unicode_playlists },
+    { "bad_track_skipping", test_bad_track_skipping },
+    { "unsupported_sample_rate_is_rejected", test_unsupported_sample_rate_is_rejected },
+    { "seek_tap_and_repeat", test_seek_tap_and_repeat },
+    { "short_track_position_is_bounded", test_short_track_position_is_bounded },
+    { "artwork_is_downscaled", test_artwork_is_downscaled },
+    { "core_identity_matches_info", test_core_identity_matches_info },
     { "save_state_restore_track_and_position", test_save_state_restore_track_and_position },
     { "pause_state_restore", test_pause_state_restore },
     { "reset_preserves_shuffle_and_restarts_current_track", test_reset_preserves_shuffle_and_restarts_current_track },
@@ -808,6 +1068,7 @@ static const TestCase kTests[] = {
     { "shuffle_previous_after_eof_returns_finished_track", test_shuffle_previous_after_eof_returns_finished_track },
     { "shuffle_save_state_restores_previous_history", test_shuffle_save_state_restores_previous_history },
     { "negative_restore_keeps_playback_usable", test_negative_restore_keeps_playback_usable },
+    { "malformed_save_states_are_rejected", test_malformed_save_states_are_rejected },
     { "config_layout_smoke", test_config_layout_smoke },
     { "vu_mode_updates_once_per_frame", test_vu_mode_updates_once_per_frame },
     { "track_change_resets_fft_visualizer_state", test_track_change_resets_fft_visualizer_state },

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import wave
+import zlib
 from pathlib import Path
 
 
@@ -57,6 +58,33 @@ def write_playlist(path: Path, entries: list[str]) -> None:
     path.write_text("\n".join(entries) + "\n", encoding="utf-8")
 
 
+def write_utf16_playlist(path: Path, entries: list[str], byte_order: str) -> None:
+    content = "\n".join(entries) + "\n"
+    if byte_order == "little":
+        path.write_bytes(b"\xff\xfe" + content.encode("utf-16-le"))
+    elif byte_order == "big":
+        path.write_bytes(b"\xfe\xff" + content.encode("utf-16-be"))
+    else:
+        raise ValueError(f"Unsupported UTF-16 byte order: {byte_order}")
+
+
+def write_png(path: Path, width: int, height: int, rgb: tuple[int, int, int]) -> None:
+    def chunk(kind: bytes, data: bytes) -> bytes:
+        checksum = zlib.crc32(kind)
+        checksum = zlib.crc32(data, checksum)
+        return struct.pack(">I", len(data)) + kind + data + struct.pack(">I", checksum & 0xFFFFFFFF)
+
+    row = b"\x00" + bytes(rgb) * width
+    pixels = row * height
+    header = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    path.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", header)
+        + chunk(b"IDAT", zlib.compress(pixels))
+        + chunk(b"IEND", b"")
+    )
+
+
 def generate_fixtures(fixtures_dir: Path) -> None:
     fixtures_dir.mkdir(parents=True, exist_ok=True)
 
@@ -67,6 +95,8 @@ def generate_fixtures(fixtures_dir: Path) -> None:
         "track_d.wav": 880.0,
         "alt_1.wav": 329.63,
         "alt_2.wav": 493.88,
+        "unicode_音.wav": 392.0,
+        "art_track.wav": 261.63,
     }
     for name, frequency in tracks.items():
         write_wave(fixtures_dir / name, frequency)
@@ -79,6 +109,17 @@ def generate_fixtures(fixtures_dir: Path) -> None:
         fixtures_dir / "playlist_alt.m3u",
         ["alt_1.wav", "alt_2.wav"],
     )
+    write_playlist(
+        fixtures_dir / "playlist_missing_middle.m3u",
+        ["track_a.wav", "missing.wav", "track_b.wav"],
+    )
+    write_playlist(fixtures_dir / "playlist_all_bad.m3u", ["missing_a.wav", "missing_b.wav"])
+    write_utf16_playlist(fixtures_dir / "playlist_utf16le.m3u", ["unicode_音.wav"], "little")
+    write_utf16_playlist(fixtures_dir / "playlist_utf16be.m3u", ["unicode_音.wav"], "big")
+    write_wave(fixtures_dir / "short.wav", 440.0, duration_seconds=0.005)
+    write_wave(fixtures_dir / "seek_long.wav", 220.0, duration_seconds=8.0)
+    write_wave(fixtures_dir / "unsupported_rate.wav", 440.0, duration_seconds=0.01, sample_rate=768_000)
+    write_png(fixtures_dir / "art_track.png", 256, 200, (30, 120, 220))
 
 
 def build_harness(repo_root: Path, temp_dir: Path, compiler: str) -> Path:
@@ -96,10 +137,12 @@ def build_harness(repo_root: Path, temp_dir: Path, compiler: str) -> Path:
         "src/config.c",
         "src/layout.c",
     ]
+    extra_cflags = shlex.split(os.environ.get("CFLAGS", ""))
     command = [
         compiler,
         "-std=c99",
         "-O2",
+        *extra_cflags,
         "-I./deps",
         "-I./src",
         "-o",


### PR DESCRIPTION
## Summary

- Add UTF-8-aware Windows file opening and UTF-16 playlist handling so media, metadata, and playlists load reliably from Unicode paths.
- Reject invalid decoder/save-state data, clean up failed loads, reset resampler state on seeks, and clamp restored UI state.
- Bound and downscale decoded artwork before storing it, and add regression coverage for Unicode playlists, malformed states, seeking, artwork, and load failures.

The previous narrow-path file APIs and permissive restore/load paths could leave playback in an inconsistent state or fail on valid Unicode content. These changes make failures atomic and keep restored playback, progress, and artwork memory within valid bounds.

## Related issue

None.

## Testing

- [x] Ran the Windows native test harness (`.\scripts\test-windows.ps1`) — 21/21 tests passed.
- [ ] Walked the runtime smoke checklist.
- [ ] Built the Windows DLL locally.

## Checklist

- [x] Code follows the C99 / 4-space project style.
- [x] Changes respect the 320x240 RGB565 display constraint.
- [x] Documentation was updated for the changed behavior.
