### PR TITLE
Hi-Fi Deck UI overhaul: new renderer, seven visualizer modes, real-time pacing, resolution scaling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,5 +18,5 @@
 
 - [ ] Code follows the C99 / 4-space style in [`CONTRIBUTING.md`](../CONTRIBUTING.md)
 - [ ] Changes respect the 320x240 RGB565 display constraint
-- [ ] New UI elements handle both responsive layout and non-responsive fallback placement
+- [ ] New UI elements are positioned from `layout.*` and respect the degradation priority (transport → title scale → viz height)
 - [ ] Documentation (README / core options) updated if behavior changed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,6 @@
 ## Checklist
 
 - [ ] Code follows the C99 / 4-space style in [`CONTRIBUTING.md`](../CONTRIBUTING.md)
-- [ ] Changes respect the 320x240 RGB565 display constraint
+- [ ] Changes respect the logical 320x240 RGB565 layout and multiply pixel constants by the resolution scale
 - [ ] New UI elements are positioned from `layout.*` and respect the degradation priority (transport → title scale → viz height)
 - [ ] Documentation (README / core options) updated if behavior changed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           clang --analyze -std=c99 -I./deps -I./src \
             src/core.c src/audio.c src/video.c src/visualizer.c \
-            src/metadata.c src/config.c src/layout.c
+            src/metadata.c src/config.c src/layout.c src/ui.c
 
   build:
     runs-on: windows-latest
@@ -138,7 +138,7 @@ jobs:
         run: |
           gcc -shared -O2 -I./deps -I./src -o music_playlist_libretro.dll \
             src/core.c src/audio.c src/audio_codecs.c src/video.c src/visualizer.c \
-            src/metadata.c src/image_codecs.c src/config.c src/layout.c -lm
+            src/metadata.c src/image_codecs.c src/config.c src/layout.c src/ui.c -lm
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ gcc -shared -O2 -I./deps -I./src -o music_playlist_libretro.dll \
 - Render within **320×240, RGB565** — never assume other dimensions.
 - Keep memory usage minimal (embedded/emulator context).
 - All UI elements are positioned from `layout.*` (computed in `layout.c`). The old non-responsive `media_*_y` offset path was removed — do not reintroduce per-element fixed coordinates.
-- On short content areas the layout degrades in a fixed order: the transport row auto-hides first, then the 2× title falls back to 1×, then the visualizer panel gives up height. Keep that priority intact when adding elements.
+- On short content areas the layout degrades in a fixed order: the transport row auto-hides first, then the 2× title falls back to 1×, then the visualizer panel gives up height (VU mode never shrinks below two meter rows). When even that cannot fit, the overflow guards drop elements bottom-up — transport, time, bar, then text — so the visualizer panel survives last. Keep that priority intact when adding elements.
 
 ## LibRetro callbacks (`core.c`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,12 +26,13 @@ UltiMedia is a LibRetro audio player and music visualizer that runs as a core pl
 | `core.c` | LibRetro callbacks, playlist loading, runtime state, shuffle flow, save/load state |
 | `audio.c` | Audio decoding, resampling, decoder snapshot restore |
 | `audio_codecs.c` | Third-party audio decoder implementations (`dr_*`, `stb_vorbis`) |
-| `video.c` | Framebuffer and display |
-| `visualizer.c` | Visualizations: Bars, VU Meter, Dots, Line |
+| `video.c` | Framebuffer, drawing primitives (fill/bevel/blend/dither), and text rendering |
+| `visualizer.c` | Visualizations: Bars, VU Meter, Dots, Line (drawn inside `layout.viz_inner`) |
 | `metadata.c` | Track metadata parsing and album-art lookup/loading |
 | `image_codecs.c` | Third-party image decoder implementation (`stb_image`) |
 | `config.c` | LibRetro core options (declare + read) |
-| `layout.c` | Responsive UI layout computation |
+| `layout.c` | Responsive UI layout computation: stack fitting, transport auto-hide, title scaling |
+| `ui.c` | Screen composition: framed art, sunken visualizer panel, marquee title, progress bar, transport icons — both responsive and manual-offset paths |
 | `stb_vorbis_compat.h` | Shared Vorbis declarations used by `audio.c` and `metadata.c` |
 | `path_io.h` | UTF-8-aware file opening and path splitting, including wide Windows paths |
 | `core_state.h` | Serialized save-state layout, shared with the test harness |
@@ -76,7 +77,7 @@ Dependencies are not committed — they're fetched into `deps/` before building.
 python3 tests/run_tests.py
 gcc -shared -O2 -I./deps -I./src -o music_playlist_libretro.dll \
   src/core.c src/audio.c src/audio_codecs.c src/video.c src/visualizer.c \
-  src/metadata.c src/image_codecs.c src/config.c src/layout.c -lm
+  src/metadata.c src/image_codecs.c src/config.c src/layout.c src/ui.c -lm
 ```
 
 **macOS / Linux** — there is no setup script here; fetch deps manually (see the `curl` block in [`CONTRIBUTING.md`](CONTRIBUTING.md)), then run `python3 tests/run_tests.py`. The harness uses `cc` by default (override with `CC=`). The distributable DLL is built on Windows; on these platforms the harness is the primary local check.
@@ -105,7 +106,8 @@ gcc -shared -O2 -I./deps -I./src -o music_playlist_libretro.dll \
 **Hard constraints**
 - Render within **320×240, RGB565** — never assume other dimensions.
 - Keep memory usage minimal (embedded/emulator context).
-- New UI elements need **both** a responsive branch (positioned from `layout.*`) **and** a non-responsive fallback (positioned from the element's `media_*_y` offset). Responsive is default-On, but the Off path is wired into every drawing routine in `core.c` and `visualizer.c` — don't break it.
+- New UI elements need **both** a responsive branch (positioned from `layout.*`) **and** a non-responsive fallback (positioned from the element's `media_*_y` offset). Responsive is default-On, but the Off path is wired into every drawing routine in `ui.c` and `visualizer.c` — don't break it.
+- On short content areas the responsive layout degrades in a fixed order: the transport row auto-hides first, then the 2× title falls back to 1×, then the visualizer panel gives up height. Keep that priority intact when adding elements.
 
 ## LibRetro callbacks (`core.c`)
 
@@ -120,7 +122,7 @@ gcc -shared -O2 -I./deps -I./src -o music_playlist_libretro.dll \
 
 All keys are prefixed `media_`, declared in `config_declare_variables()` and read in `config_update()`. Defaults in parentheses.
 
-- **Visibility (On/Off, all On):** `media_show_art`, `media_show_txt`, `media_show_viz`, `media_show_bar`, `media_show_tim`, `media_show_ico`
+- **Visibility (On/Off, all On):** `media_show_art`, `media_show_txt`, `media_show_viz`, `media_show_bar`, `media_show_tim`, `media_show_ico` (transport icon row — additionally auto-hides in responsive mode when the content area is too short)
 - **Responsive layout:** `media_responsive` (On), `media_debug_layout` (Off), and usable-region bounds `media_ui_top` (20), `media_ui_bottom` (80), `media_ui_left` (10), `media_ui_right` (90), as percentages
 - **Manual Y offsets** (used mainly when responsive is Off): `media_art_y` (40), `media_txt_y` (150), `media_viz_y` (140), `media_bar_y` (180), `media_tim_y` (190), `media_ico_y` (20)
 - **Visualizer:** `media_viz_mode` (`Bars` | `VU Meter` | `Dots` | `Line`; legacy `FFT EQ` maps to `Bars`), `media_viz_bands` (40; presets 40/20), `media_viz_gradient` (On), `media_viz_peak_hold` (30)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ UltiMedia is a LibRetro audio player and music visualizer that runs as a core pl
 | `audio.c` | Audio decoding, resampling, decoder snapshot restore |
 | `audio_codecs.c` | Third-party audio decoder implementations (`dr_*`, `stb_vorbis`) |
 | `video.c` | Framebuffer, drawing primitives (fill/bevel/blend/dither), and text rendering |
-| `visualizer.c` | Visualizations: Bars, VU Meter, Dots, Line, Scope (drawn inside `layout.viz_inner`) |
+| `visualizer.c` | Visualizations: Bars, VU Meter, Dots, Line, Scope, Mirror (drawn inside `layout.viz_inner`) |
 | `metadata.c` | Track metadata parsing and album-art lookup/loading |
 | `image_codecs.c` | Third-party image decoder implementation (`stb_image`) |
 | `config.c` | LibRetro core options (declare + read) |
@@ -124,7 +124,7 @@ All keys are prefixed `media_`, declared in `config_declare_variables()` and rea
 
 - **Visibility (On/Off, all On):** `media_show_art`, `media_show_txt`, `media_show_viz`, `media_show_bar`, `media_show_tim`, `media_show_ico` (transport icon row — additionally auto-hides when the content area is too short)
 - **Layout:** `media_debug_layout` (Off) and usable-region bounds `media_ui_top` (20), `media_ui_bottom` (80), `media_ui_left` (10), `media_ui_right` (90), as percentages
-- **Visualizer:** `media_viz_mode` (`Bars` | `VU Meter` | `Dots` | `Line` | `Scope`; legacy `FFT EQ` maps to `Bars`), `media_viz_bands` (40; presets 40/20), `media_viz_gradient` (On), `media_viz_peak_hold` (30)
+- **Visualizer:** `media_viz_mode` (`Bars` | `VU Meter` | `Dots` | `Line` | `Scope` | `Mirror`; legacy `FFT EQ` maps to `Bars`), `media_viz_bands` (40; presets 40/20), `media_viz_gradient` (On), `media_viz_peak_hold` (30)
 - **Track text:** `media_use_filename` — `Show ID` (metadata) | `Show filename with extension` | `Show Filename without extension`
 - **Colors:** six 0–255 channels `media_bg_r/g/b` (0/64/0) and `media_fg_r/g/b` (0/255/0), packed into `cfg.bg_rgb` / `cfg.fg_rgb` as RGB565
 
@@ -133,7 +133,7 @@ All keys are prefixed `media_`, declared in `config_declare_variables()` and rea
 | Button | Action |
 |---|---|
 | `B` | Pause / Play |
-| `X` | Cycle visualizer (`Bars → VU Meter → Dots → Line → Scope`) |
+| `X` | Cycle visualizer (`Bars → VU Meter → Dots → Line → Scope → Mirror`) |
 | `L` / `R` | Previous / Next track |
 | `LEFT` / `RIGHT` | Seek backward / forward ~3 seconds |
 | `Y` | Toggle shuffle |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ gcc -shared -O2 -I./deps -I./src -o music_playlist_libretro.dll \
 
 All keys are prefixed `media_`, declared in `config_declare_variables()` and read in `config_update()`. Defaults in parentheses.
 
-- **Visibility (On/Off, all On):** `media_show_art`, `media_show_txt`, `media_show_viz`, `media_show_bar`, `media_show_tim`, `media_show_ico` (transport icon row — additionally auto-hides in responsive mode when the content area is too short)
+- **Visibility (On/Off, all On):** `media_show_art`, `media_show_txt`, `media_show_viz`, `media_show_bar`, `media_show_tim`, `media_show_ico` (transport icon row — additionally auto-hides when the content area is too short)
 - **Layout:** `media_debug_layout` (Off) and usable-region bounds `media_ui_top` (20), `media_ui_bottom` (80), `media_ui_left` (10), `media_ui_right` (90), as percentages
 - **Visualizer:** `media_viz_mode` (`Bars` | `VU Meter` | `Dots` | `Line`; legacy `FFT EQ` maps to `Bars`), `media_viz_bands` (40; presets 40/20), `media_viz_gradient` (On), `media_viz_peak_hold` (30)
 - **Track text:** `media_use_filename` — `Show ID` (metadata) | `Show filename with extension` | `Show Filename without extension`
@@ -145,7 +145,7 @@ Input descriptors for these are registered via `RETRO_ENVIRONMENT_SET_INPUT_DESC
 1. Put audio/visual logic in the matching `src/` module.
 2. Validate with `python3 tests/run_tests.py` first; for changes that touch runtime UX, also walk [`tests/SMOKE_CHECKLIST.md`](tests/SMOKE_CHECKLIST.md) in a frontend.
 3. Respect the 320×240 / RGB565 / minimal-memory constraints.
-4. Handle both responsive and non-responsive placement for new UI elements.
+4. Position new UI elements from `layout.*` and slot them into the degradation priority (transport → title scale → viz height).
 5. Keep `CLAUDE.md`, `CONTRIBUTING.md`, and `music_playlist_libretro.info` consistent with what the code actually does.
 
 **Automation boundary:** the repo has GitHub Actions that can run Claude on GitHub events (`.github/workflows/claude.yml`). For local work, do **not** auto-branch, push, open PRs, or merge unless the task explicitly asks for it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ UltiMedia is a LibRetro audio player and music visualizer that runs as a core pl
 |---|---|
 | Language | C99 |
 | Shipped artifact | `music_playlist_libretro.dll` (Windows LibRetro core) |
-| Display | 320×240, RGB565 |
+| Display | Integer multiples of 320×240 (1×–4×, up to 1280×960) via `media_resolution`, RGB565 |
 | Audio | 48000 Hz output, 800 samples/frame |
 | Run tests | `python3 tests/run_tests.py` |
 | LibRetro API | RetroArch `1.7.5` header |
@@ -104,7 +104,8 @@ gcc -shared -O2 -I./deps -I./src -o music_playlist_libretro.dll \
 ```
 
 **Hard constraints**
-- Render within **320×240, RGB565** — never assume other dimensions.
+- The UI is authored at a logical **320×240** and multiplied by `cfg.ui_scale` (1×–4×, from `media_resolution`; framebuffer up to 1280×960, always RGB565). Position from `layout.*`, size against `fb_width`/`fb_height`, and multiply new pixel constants by the scale — never hardcode 320/240.
+- Resolution switches mid-session go through `RETRO_ENVIRONMENT_SET_GEOMETRY` within the pre-declared max — never `SET_SYSTEM_AV_INFO`, whose driver reinit can tear down EmuVR's shared-texture pipeline.
 - Keep memory usage minimal (embedded/emulator context).
 - All UI elements are positioned from `layout.*` (computed in `layout.c`). The old non-responsive `media_*_y` offset path was removed — do not reintroduce per-element fixed coordinates.
 - On short content areas the layout degrades in a fixed order: the transport row auto-hides first, then the 2× title falls back to 1×, then the visualizer panel gives up height (VU mode never shrinks below two meter rows). When even that cannot fit, the overflow guards drop elements bottom-up — transport, time, bar, then text — so the visualizer panel survives last. Keep that priority intact when adding elements.
@@ -123,7 +124,7 @@ gcc -shared -O2 -I./deps -I./src -o music_playlist_libretro.dll \
 All keys are prefixed `media_`, declared in `config_declare_variables()` and read in `config_update()`. Defaults in parentheses.
 
 - **Visibility (On/Off, all On):** `media_show_art`, `media_show_txt`, `media_show_viz`, `media_show_bar`, `media_show_tim`, `media_show_ico` (transport icon row — additionally auto-hides when the content area is too short)
-- **Layout:** `media_debug_layout` (Off) and usable-region bounds `media_ui_top` (20), `media_ui_bottom` (80), `media_ui_left` (10), `media_ui_right` (90), as percentages
+- **Layout:** `media_resolution` (`320x240` | `640x480` | `960x720` | `1280x960`, default `320x240`), `media_debug_layout` (Off), and usable-region bounds `media_ui_top` (20), `media_ui_bottom` (80), `media_ui_left` (10), `media_ui_right` (90), as percentages
 - **Visualizer:** `media_viz_mode` (`Bars` | `VU Meter` | `Dots` | `Line` | `Scope` | `Mirror` | `Horizon`; legacy `FFT EQ` maps to `Bars`), `media_viz_bands` (40; presets 40/20), `media_viz_gradient` (On), `media_viz_peak_hold` (30; no effect in Scope/Horizon)
 - **Track text:** `media_use_filename` — `Show ID` (metadata) | `Show filename with extension` | `Show Filename without extension`
 - **Colors:** six 0–255 channels `media_bg_r/g/b` (0/64/0) and `media_fg_r/g/b` (0/255/0), packed into `cfg.bg_rgb` / `cfg.fg_rgb` as RGB565

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ UltiMedia is a LibRetro audio player and music visualizer that runs as a core pl
 | `image_codecs.c` | Third-party image decoder implementation (`stb_image`) |
 | `config.c` | LibRetro core options (declare + read) |
 | `layout.c` | Responsive UI layout computation: stack fitting, transport auto-hide, title scaling |
-| `ui.c` | Screen composition: framed art, sunken visualizer panel, marquee title, progress bar, transport icons — both responsive and manual-offset paths |
+| `ui.c` | Screen composition: framed art, sunken visualizer panel, marquee title, progress bar, transport icons |
 | `stb_vorbis_compat.h` | Shared Vorbis declarations used by `audio.c` and `metadata.c` |
 | `path_io.h` | UTF-8-aware file opening and path splitting, including wide Windows paths |
 | `core_state.h` | Serialized save-state layout, shared with the test harness |
@@ -106,8 +106,8 @@ gcc -shared -O2 -I./deps -I./src -o music_playlist_libretro.dll \
 **Hard constraints**
 - Render within **320×240, RGB565** — never assume other dimensions.
 - Keep memory usage minimal (embedded/emulator context).
-- New UI elements need **both** a responsive branch (positioned from `layout.*`) **and** a non-responsive fallback (positioned from the element's `media_*_y` offset). Responsive is default-On, but the Off path is wired into every drawing routine in `ui.c` and `visualizer.c` — don't break it.
-- On short content areas the responsive layout degrades in a fixed order: the transport row auto-hides first, then the 2× title falls back to 1×, then the visualizer panel gives up height. Keep that priority intact when adding elements.
+- All UI elements are positioned from `layout.*` (computed in `layout.c`). The old non-responsive `media_*_y` offset path was removed — do not reintroduce per-element fixed coordinates.
+- On short content areas the layout degrades in a fixed order: the transport row auto-hides first, then the 2× title falls back to 1×, then the visualizer panel gives up height. Keep that priority intact when adding elements.
 
 ## LibRetro callbacks (`core.c`)
 
@@ -123,8 +123,7 @@ gcc -shared -O2 -I./deps -I./src -o music_playlist_libretro.dll \
 All keys are prefixed `media_`, declared in `config_declare_variables()` and read in `config_update()`. Defaults in parentheses.
 
 - **Visibility (On/Off, all On):** `media_show_art`, `media_show_txt`, `media_show_viz`, `media_show_bar`, `media_show_tim`, `media_show_ico` (transport icon row — additionally auto-hides in responsive mode when the content area is too short)
-- **Responsive layout:** `media_responsive` (On), `media_debug_layout` (Off), and usable-region bounds `media_ui_top` (20), `media_ui_bottom` (80), `media_ui_left` (10), `media_ui_right` (90), as percentages
-- **Manual Y offsets** (used mainly when responsive is Off): `media_art_y` (40), `media_txt_y` (150), `media_viz_y` (140), `media_bar_y` (180), `media_tim_y` (190), `media_ico_y` (20)
+- **Layout:** `media_debug_layout` (Off) and usable-region bounds `media_ui_top` (20), `media_ui_bottom` (80), `media_ui_left` (10), `media_ui_right` (90), as percentages
 - **Visualizer:** `media_viz_mode` (`Bars` | `VU Meter` | `Dots` | `Line`; legacy `FFT EQ` maps to `Bars`), `media_viz_bands` (40; presets 40/20), `media_viz_gradient` (On), `media_viz_peak_hold` (30)
 - **Track text:** `media_use_filename` — `Show ID` (metadata) | `Show filename with extension` | `Show Filename without extension`
 - **Colors:** six 0–255 channels `media_bg_r/g/b` (0/64/0) and `media_fg_r/g/b` (0/255/0), packed into `cfg.bg_rgb` / `cfg.fg_rgb` as RGB565

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ UltiMedia is a LibRetro audio player and music visualizer that runs as a core pl
 | `audio.c` | Audio decoding, resampling, decoder snapshot restore |
 | `audio_codecs.c` | Third-party audio decoder implementations (`dr_*`, `stb_vorbis`) |
 | `video.c` | Framebuffer, drawing primitives (fill/bevel/blend/dither), and text rendering |
-| `visualizer.c` | Visualizations: Bars, VU Meter, Dots, Line (drawn inside `layout.viz_inner`) |
+| `visualizer.c` | Visualizations: Bars, VU Meter, Dots, Line, Scope (drawn inside `layout.viz_inner`) |
 | `metadata.c` | Track metadata parsing and album-art lookup/loading |
 | `image_codecs.c` | Third-party image decoder implementation (`stb_image`) |
 | `config.c` | LibRetro core options (declare + read) |
@@ -124,7 +124,7 @@ All keys are prefixed `media_`, declared in `config_declare_variables()` and rea
 
 - **Visibility (On/Off, all On):** `media_show_art`, `media_show_txt`, `media_show_viz`, `media_show_bar`, `media_show_tim`, `media_show_ico` (transport icon row — additionally auto-hides when the content area is too short)
 - **Layout:** `media_debug_layout` (Off) and usable-region bounds `media_ui_top` (20), `media_ui_bottom` (80), `media_ui_left` (10), `media_ui_right` (90), as percentages
-- **Visualizer:** `media_viz_mode` (`Bars` | `VU Meter` | `Dots` | `Line`; legacy `FFT EQ` maps to `Bars`), `media_viz_bands` (40; presets 40/20), `media_viz_gradient` (On), `media_viz_peak_hold` (30)
+- **Visualizer:** `media_viz_mode` (`Bars` | `VU Meter` | `Dots` | `Line` | `Scope`; legacy `FFT EQ` maps to `Bars`), `media_viz_bands` (40; presets 40/20), `media_viz_gradient` (On), `media_viz_peak_hold` (30)
 - **Track text:** `media_use_filename` — `Show ID` (metadata) | `Show filename with extension` | `Show Filename without extension`
 - **Colors:** six 0–255 channels `media_bg_r/g/b` (0/64/0) and `media_fg_r/g/b` (0/255/0), packed into `cfg.bg_rgb` / `cfg.fg_rgb` as RGB565
 
@@ -133,7 +133,7 @@ All keys are prefixed `media_`, declared in `config_declare_variables()` and rea
 | Button | Action |
 |---|---|
 | `B` | Pause / Play |
-| `X` | Cycle visualizer (`Bars → VU Meter → Dots → Line`) |
+| `X` | Cycle visualizer (`Bars → VU Meter → Dots → Line → Scope`) |
 | `L` / `R` | Previous / Next track |
 | `LEFT` / `RIGHT` | Seek backward / forward ~3 seconds |
 | `Y` | Toggle shuffle |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ UltiMedia is a LibRetro audio player and music visualizer that runs as a core pl
 | `audio.c` | Audio decoding, resampling, decoder snapshot restore |
 | `audio_codecs.c` | Third-party audio decoder implementations (`dr_*`, `stb_vorbis`) |
 | `video.c` | Framebuffer, drawing primitives (fill/bevel/blend/dither), and text rendering |
-| `visualizer.c` | Visualizations: Bars, VU Meter, Dots, Line, Scope, Mirror (drawn inside `layout.viz_inner`) |
+| `visualizer.c` | Visualizations: Bars, VU Meter, Dots, Line, Scope, Mirror, Horizon (drawn inside `layout.viz_inner`) |
 | `metadata.c` | Track metadata parsing and album-art lookup/loading |
 | `image_codecs.c` | Third-party image decoder implementation (`stb_image`) |
 | `config.c` | LibRetro core options (declare + read) |
@@ -124,7 +124,7 @@ All keys are prefixed `media_`, declared in `config_declare_variables()` and rea
 
 - **Visibility (On/Off, all On):** `media_show_art`, `media_show_txt`, `media_show_viz`, `media_show_bar`, `media_show_tim`, `media_show_ico` (transport icon row — additionally auto-hides when the content area is too short)
 - **Layout:** `media_debug_layout` (Off) and usable-region bounds `media_ui_top` (20), `media_ui_bottom` (80), `media_ui_left` (10), `media_ui_right` (90), as percentages
-- **Visualizer:** `media_viz_mode` (`Bars` | `VU Meter` | `Dots` | `Line` | `Scope` | `Mirror`; legacy `FFT EQ` maps to `Bars`), `media_viz_bands` (40; presets 40/20), `media_viz_gradient` (On), `media_viz_peak_hold` (30)
+- **Visualizer:** `media_viz_mode` (`Bars` | `VU Meter` | `Dots` | `Line` | `Scope` | `Mirror` | `Horizon`; legacy `FFT EQ` maps to `Bars`), `media_viz_bands` (40; presets 40/20), `media_viz_gradient` (On), `media_viz_peak_hold` (30; no effect in Scope/Horizon)
 - **Track text:** `media_use_filename` — `Show ID` (metadata) | `Show filename with extension` | `Show Filename without extension`
 - **Colors:** six 0–255 channels `media_bg_r/g/b` (0/64/0) and `media_fg_r/g/b` (0/255/0), packed into `cfg.bg_rgb` / `cfg.fg_rgb` as RGB565
 
@@ -133,7 +133,7 @@ All keys are prefixed `media_`, declared in `config_declare_variables()` and rea
 | Button | Action |
 |---|---|
 | `B` | Pause / Play |
-| `X` | Cycle visualizer (`Bars → VU Meter → Dots → Line → Scope → Mirror`) |
+| `X` | Cycle visualizer (`Bars → VU Meter → Dots → Line → Scope → Mirror → Horizon`) |
 | `L` / `R` | Previous / Next track |
 | `LEFT` / `RIGHT` | Seek backward / forward ~3 seconds |
 | `Y` | Toggle shuffle |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ Key constants:
 
 ### Constraints to respect
 
-- The display is fixed at **320x240, RGB565** — keep rendering within those bounds.
+- The UI is authored at a logical **320x240, RGB565** and multiplied by the resolution scale (`cfg.ui_scale`, 1x-4x) — position from `layout.*` and multiply pixel constants by the scale.
 - Keep memory usage minimal (embedded/emulator context).
 - **New UI elements are positioned from `layout.*` and should slot into the layout's degradation priority (transport → title scale → visualizer height).** Put audio/visual logic in the matching `src/` module.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ All source lives in `src/`, split by responsibility:
 | `audio.c` | Audio decoding, resampling, decoder snapshot restore |
 | `audio_codecs.c` | Third-party audio decoder implementations (`dr_*`, `stb_vorbis`) |
 | `video.c` | Framebuffer, drawing primitives (fill/bevel/blend/dither), and text rendering |
-| `visualizer.c` | Audio visualizations (Bars, VU Meter, Dots, Line) |
+| `visualizer.c` | Audio visualizations (Bars, VU Meter, Dots, Line, Scope) |
 | `metadata.c` | Track metadata parsing and album art lookup/loading |
 | `image_codecs.c` | Third-party image decoder implementation (`stb_image`) |
 | `config.c` | LibRetro core options |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ All source lives in `src/`, split by responsibility:
 | `audio.c` | Audio decoding, resampling, decoder snapshot restore |
 | `audio_codecs.c` | Third-party audio decoder implementations (`dr_*`, `stb_vorbis`) |
 | `video.c` | Framebuffer, drawing primitives (fill/bevel/blend/dither), and text rendering |
-| `visualizer.c` | Audio visualizations (Bars, VU Meter, Dots, Line, Scope) |
+| `visualizer.c` | Audio visualizations (Bars, VU Meter, Dots, Line, Scope, Mirror) |
 | `metadata.c` | Track metadata parsing and album art lookup/loading |
 | `image_codecs.c` | Third-party image decoder implementation (`stb_image`) |
 | `config.c` | LibRetro core options |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,12 +19,13 @@ All source lives in `src/`, split by responsibility:
 | `core.c` | LibRetro callbacks, playlist loading, runtime state, shuffle, save/load state |
 | `audio.c` | Audio decoding, resampling, decoder snapshot restore |
 | `audio_codecs.c` | Third-party audio decoder implementations (`dr_*`, `stb_vorbis`) |
-| `video.c` | Framebuffer and display |
+| `video.c` | Framebuffer, drawing primitives (fill/bevel/blend/dither), and text rendering |
 | `visualizer.c` | Audio visualizations (Bars, VU Meter, Dots, Line) |
 | `metadata.c` | Track metadata parsing and album art lookup/loading |
 | `image_codecs.c` | Third-party image decoder implementation (`stb_image`) |
 | `config.c` | LibRetro core options |
 | `layout.c` | Responsive UI layout computation |
+| `ui.c` | Screen composition: framed art, visualizer panel, marquee title, progress bar, transport icons |
 | `path_io.h` | UTF-8-aware file opening, including wide Windows paths |
 
 Tests live in `tests/`, and the Windows contributor helpers in `scripts/`.
@@ -83,7 +84,7 @@ To build the core manually inside a UCRT64 shell (with `deps/` already populated
 ```bash
 gcc -shared -O2 -I./deps -I./src -o music_playlist_libretro.dll \
   src/core.c src/audio.c src/audio_codecs.c src/video.c src/visualizer.c \
-  src/metadata.c src/image_codecs.c src/config.c src/layout.c -lm
+  src/metadata.c src/image_codecs.c src/config.c src/layout.c src/ui.c -lm
 ```
 
 ## Code style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ All source lives in `src/`, split by responsibility:
 | `audio.c` | Audio decoding, resampling, decoder snapshot restore |
 | `audio_codecs.c` | Third-party audio decoder implementations (`dr_*`, `stb_vorbis`) |
 | `video.c` | Framebuffer, drawing primitives (fill/bevel/blend/dither), and text rendering |
-| `visualizer.c` | Audio visualizations (Bars, VU Meter, Dots, Line, Scope, Mirror) |
+| `visualizer.c` | Audio visualizations (Bars, VU Meter, Dots, Line, Scope, Mirror, Horizon) |
 | `metadata.c` | Track metadata parsing and album art lookup/loading |
 | `image_codecs.c` | Third-party image decoder implementation (`stb_image`) |
 | `config.c` | LibRetro core options |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ Key constants:
 
 - The display is fixed at **320x240, RGB565** — keep rendering within those bounds.
 - Keep memory usage minimal (embedded/emulator context).
-- **New UI elements usually need both responsive layout handling and a non-responsive fallback placement.** Put audio/visual logic in the matching `src/` module.
+- **New UI elements are positioned from `layout.*` and should slot into the layout's degradation priority (transport → title scale → visualizer height).** Put audio/visual logic in the matching `src/` module.
 
 ## Testing your changes
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ When a track loads, art is searched in this order:
 
 ### Layout
 
+- Resolution: `320x240` (default), `640x480`, `960x720`, or `1280x960`
 - UI Top / Bottom / Left / Right (%): defines the usable screen region
 - Debug Layout Bounds: `Off/On`
   - Draws colored layout boxes to help tune positioning

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ If you prefer working inside an MSYS2 shell directly, open the `UCRT64` shell. M
 python3 tests/run_tests.py
 gcc -shared -O2 -I./deps -I./src -o music_playlist_libretro.dll \
   src/core.c src/audio.c src/audio_codecs.c src/video.c src/visualizer.c \
-  src/metadata.c src/image_codecs.c src/config.c src/layout.c -lm
+  src/metadata.c src/image_codecs.c src/config.c src/layout.c src/ui.c -lm
 ```
 
 ### CI Coverage

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ When a track loads, art is searched in this order:
 - Show Visualizer
 - Show Progress Bar
 - Show Time
-- Show Icons
+- Show Transport Icons (also auto-hides on its own when the layout gets too short)
 
 ### Visualizer
 
@@ -85,21 +85,11 @@ When a track loads, art is searched in this order:
   - `Show filename with extension`
   - `Show Filename without extension`
 
-### Responsive Layout
+### Layout
 
-- Responsive Layout: `On/Off` (default `On`)
 - UI Top / Bottom / Left / Right (%): defines the usable screen region
 - Debug Layout Bounds: `Off/On`
-  - Draws colored layout boxes to help tune responsive positioning
-
-### Manual Y Offsets (mainly for non-responsive mode)
-
-- Art Y
-- Text Y
-- Viz Y
-- Bar Y
-- Time Y
-- Icon Y
+  - Draws colored layout boxes to help tune positioning
 
 ### Colors
 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ This keeps EmuVR/RetroArch from handing images or media to the built-in viewers 
 - Read `M3U` playlists (UTF-8 and UTF-16)
 - Parse metadata from MP3, OGG, and FLAC tags
 - Show album art from nearby image files or embedded artwork
-- Display 6 visualizer modes: `Bars`, `VU Meter`, `Dots`, `Line`, `Scope`, `Mirror`
+- Display 7 visualizer modes: `Bars`, `VU Meter`, `Dots`, `Line`, `Scope`, `Mirror`, `Horizon`
 - Auto-arrange UI with responsive layout bounds
 - Preserve playback, pause, and shuffle state through LibRetro save states
 
 ## Controls
 
 - `B`: Pause/Play
-- `X`: Cycle visualizer mode (`Bars -> VU Meter -> Dots -> Line -> Scope -> Mirror`)
+- `X`: Cycle visualizer mode (`Bars -> VU Meter -> Dots -> Line -> Scope -> Mirror -> Horizon`)
 - `L` / `R`: Previous / Next track
 - `LEFT` / `RIGHT`: Seek backward / forward by about 3 seconds
 - `Y`: Toggle shuffle
@@ -73,7 +73,7 @@ When a track loads, art is searched in this order:
 
 ### Visualizer
 
-- Viz Mode: `Bars`, `VU Meter`, `Dots`, `Line`, `Scope`, `Mirror`
+- Viz Mode: `Bars`, `VU Meter`, `Dots`, `Line`, `Scope`, `Mirror`, `Horizon`
 - Viz Bands: `20` or `40`
 - Viz Gradient: `On/Off`
 - Peak Hold presets: `0`, `15`, `30`, `45`, `60` (default `30`)

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ This keeps EmuVR/RetroArch from handing images or media to the built-in viewers 
 - Read `M3U` playlists (UTF-8 and UTF-16)
 - Parse metadata from MP3, OGG, and FLAC tags
 - Show album art from nearby image files or embedded artwork
-- Display 5 visualizer modes: `Bars`, `VU Meter`, `Dots`, `Line`, `Scope`
+- Display 6 visualizer modes: `Bars`, `VU Meter`, `Dots`, `Line`, `Scope`, `Mirror`
 - Auto-arrange UI with responsive layout bounds
 - Preserve playback, pause, and shuffle state through LibRetro save states
 
 ## Controls
 
 - `B`: Pause/Play
-- `X`: Cycle visualizer mode (`Bars -> VU Meter -> Dots -> Line -> Scope`)
+- `X`: Cycle visualizer mode (`Bars -> VU Meter -> Dots -> Line -> Scope -> Mirror`)
 - `L` / `R`: Previous / Next track
 - `LEFT` / `RIGHT`: Seek backward / forward by about 3 seconds
 - `Y`: Toggle shuffle
@@ -73,7 +73,7 @@ When a track loads, art is searched in this order:
 
 ### Visualizer
 
-- Viz Mode: `Bars`, `VU Meter`, `Dots`, `Line`, `Scope`
+- Viz Mode: `Bars`, `VU Meter`, `Dots`, `Line`, `Scope`, `Mirror`
 - Viz Bands: `20` or `40`
 - Viz Gradient: `On/Off`
 - Peak Hold presets: `0`, `15`, `30`, `45`, `60` (default `30`)

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ This keeps EmuVR/RetroArch from handing images or media to the built-in viewers 
 - Read `M3U` playlists (UTF-8 and UTF-16)
 - Parse metadata from MP3, OGG, and FLAC tags
 - Show album art from nearby image files or embedded artwork
-- Display 4 visualizer modes: `Bars`, `VU Meter`, `Dots`, `Line`
+- Display 5 visualizer modes: `Bars`, `VU Meter`, `Dots`, `Line`, `Scope`
 - Auto-arrange UI with responsive layout bounds
 - Preserve playback, pause, and shuffle state through LibRetro save states
 
 ## Controls
 
 - `B`: Pause/Play
-- `X`: Cycle visualizer mode (`Bars -> VU Meter -> Dots -> Line`)
+- `X`: Cycle visualizer mode (`Bars -> VU Meter -> Dots -> Line -> Scope`)
 - `L` / `R`: Previous / Next track
 - `LEFT` / `RIGHT`: Seek backward / forward by about 3 seconds
 - `Y`: Toggle shuffle
@@ -73,7 +73,7 @@ When a track loads, art is searched in this order:
 
 ### Visualizer
 
-- Viz Mode: `Bars`, `VU Meter`, `Dots`, `Line`
+- Viz Mode: `Bars`, `VU Meter`, `Dots`, `Line`, `Scope`
 - Viz Bands: `20` or `40`
 - Viz Gradient: `On/Off`
 - Peak Hold presets: `0`, `15`, `30`, `45`, `60` (default `30`)

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -6,7 +6,7 @@ Write-Host "Bootstrapping Windows build prerequisites..."
 $commands = @(
     "pacman -S --needed --noconfirm mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-python curl"
 ) + (Get-UltiMediaDependencyCommands) + @(
-    "gcc -shared -O2 -I./deps -I./src -o music_playlist_libretro.dll src/core.c src/audio.c src/audio_codecs.c src/video.c src/visualizer.c src/metadata.c src/image_codecs.c src/config.c src/layout.c -lm"
+    "gcc -shared -O2 -I./deps -I./src -o music_playlist_libretro.dll src/core.c src/audio.c src/audio_codecs.c src/video.c src/visualizer.c src/metadata.c src/image_codecs.c src/config.c src/layout.c src/ui.c -lm"
 )
 
 Invoke-UltiMediaMsys -Commands $commands

--- a/src/config.c
+++ b/src/config.c
@@ -121,7 +121,7 @@ void config_declare_variables(retro_environment_t cb) {
         { "media_fg_r", "FG Red; 0|32|64|128|255" }, { "media_fg_g", "FG Green; 255|0|32|64|128" }, { "media_fg_b", "FG Blue; 0|32|64|128|255" },
         { "media_show_art", "Show Art; On|Off" }, { "media_show_txt", "Show Scroll Text; On|Off" },
         { "media_show_viz", "Show Visualizer; On|Off" }, { "media_show_bar", "Show Progress Bar; On|Off" },
-        { "media_show_tim", "Show Time; On|Off" }, { "media_show_ico", "Show Icons; On|Off" },
+        { "media_show_tim", "Show Time; On|Off" }, { "media_show_ico", "Show Transport Icons; On|Off" },
         { "media_responsive", "Responsive Layout; On|Off" },
         { "media_debug_layout", "Debug Layout Bounds; Off|On" },
         { "media_ui_top", "UI Top %; 20|0|10|30|40|50" },

--- a/src/config.c
+++ b/src/config.c
@@ -80,6 +80,12 @@ void config_update(retro_environment_t environ_cb) {
     cfg.show_bar = get_bool_var(environ_cb, "media_show_bar", true);
     cfg.show_tim = get_bool_var(environ_cb, "media_show_tim", true);
     cfg.show_ico = get_bool_var(environ_cb, "media_show_ico", true);
+    const char *res_value = get_var_value(environ_cb, "media_resolution");
+    if (res_value && !strcmp(res_value, "1280x960")) cfg.ui_scale = 4;
+    else if (res_value && !strcmp(res_value, "960x720")) cfg.ui_scale = 3;
+    else if (res_value && !strcmp(res_value, "640x480")) cfg.ui_scale = 2;
+    else cfg.ui_scale = 1;
+
     cfg.debug_layout = get_bool_var(environ_cb, "media_debug_layout", false);
     cfg.ui_top = get_int_var(environ_cb, "media_ui_top", 20, 0, 100);
     cfg.ui_bottom = get_int_var(environ_cb, "media_ui_bottom", 80, 0, 100);
@@ -118,6 +124,7 @@ void config_declare_variables(retro_environment_t cb) {
         { "media_show_art", "Show Art; On|Off" }, { "media_show_txt", "Show Scroll Text; On|Off" },
         { "media_show_viz", "Show Visualizer; On|Off" }, { "media_show_bar", "Show Progress Bar; On|Off" },
         { "media_show_tim", "Show Time; On|Off" }, { "media_show_ico", "Show Transport Icons; On|Off" },
+        { "media_resolution", "Resolution; 320x240|640x480|960x720|1280x960" },
         { "media_debug_layout", "Debug Layout Bounds; Off|On" },
         { "media_ui_top", "UI Top %; 20|0|10|30|40|50" },
         { "media_ui_bottom", "UI Bottom %; 80|50|60|70|90|100" },

--- a/src/config.c
+++ b/src/config.c
@@ -97,6 +97,7 @@ void config_update(retro_environment_t environ_cb) {
         else if (!strcmp(viz_mode_value, "VU Meter")) cfg.viz_mode = VIZ_MODE_VU;
         else if (!strcmp(viz_mode_value, "Dots")) cfg.viz_mode = VIZ_MODE_DOTS;
         else if (!strcmp(viz_mode_value, "Line")) cfg.viz_mode = VIZ_MODE_LINE;
+        else if (!strcmp(viz_mode_value, "Scope")) cfg.viz_mode = VIZ_MODE_SCOPE;
         else cfg.viz_mode = VIZ_MODE_BARS;
     } else {
         cfg.viz_mode = VIZ_MODE_BARS;
@@ -121,7 +122,7 @@ void config_declare_variables(retro_environment_t cb) {
         { "media_ui_left", "UI Left %; 10|0|20|30" },
         { "media_ui_right", "UI Right %; 90|70|80|100" },
         { "media_viz_bands", "Viz Bands; 40|20" },
-        { "media_viz_mode", "Viz Mode; Bars|VU Meter|Dots|Line" },
+        { "media_viz_mode", "Viz Mode; Bars|VU Meter|Dots|Line|Scope" },
         { "media_viz_gradient", "Viz Gradient; On|Off" },
         { "media_viz_peak_hold", "Peak Hold; 30|0|15|45|60" },
         { "media_use_filename", "Track Text Mode; Show ID|Show filename with extension|Show Filename without extension" },

--- a/src/config.c
+++ b/src/config.c
@@ -98,6 +98,7 @@ void config_update(retro_environment_t environ_cb) {
         else if (!strcmp(viz_mode_value, "Dots")) cfg.viz_mode = VIZ_MODE_DOTS;
         else if (!strcmp(viz_mode_value, "Line")) cfg.viz_mode = VIZ_MODE_LINE;
         else if (!strcmp(viz_mode_value, "Scope")) cfg.viz_mode = VIZ_MODE_SCOPE;
+        else if (!strcmp(viz_mode_value, "Mirror")) cfg.viz_mode = VIZ_MODE_MIRROR;
         else cfg.viz_mode = VIZ_MODE_BARS;
     } else {
         cfg.viz_mode = VIZ_MODE_BARS;
@@ -122,7 +123,7 @@ void config_declare_variables(retro_environment_t cb) {
         { "media_ui_left", "UI Left %; 10|0|20|30" },
         { "media_ui_right", "UI Right %; 90|70|80|100" },
         { "media_viz_bands", "Viz Bands; 40|20" },
-        { "media_viz_mode", "Viz Mode; Bars|VU Meter|Dots|Line|Scope" },
+        { "media_viz_mode", "Viz Mode; Bars|VU Meter|Dots|Line|Scope|Mirror" },
         { "media_viz_gradient", "Viz Gradient; On|Off" },
         { "media_viz_peak_hold", "Peak Hold; 30|0|15|45|60" },
         { "media_use_filename", "Track Text Mode; Show ID|Show filename with extension|Show Filename without extension" },

--- a/src/config.c
+++ b/src/config.c
@@ -99,6 +99,7 @@ void config_update(retro_environment_t environ_cb) {
         else if (!strcmp(viz_mode_value, "Line")) cfg.viz_mode = VIZ_MODE_LINE;
         else if (!strcmp(viz_mode_value, "Scope")) cfg.viz_mode = VIZ_MODE_SCOPE;
         else if (!strcmp(viz_mode_value, "Mirror")) cfg.viz_mode = VIZ_MODE_MIRROR;
+        else if (!strcmp(viz_mode_value, "Horizon")) cfg.viz_mode = VIZ_MODE_HORIZON;
         else cfg.viz_mode = VIZ_MODE_BARS;
     } else {
         cfg.viz_mode = VIZ_MODE_BARS;
@@ -123,7 +124,7 @@ void config_declare_variables(retro_environment_t cb) {
         { "media_ui_left", "UI Left %; 10|0|20|30" },
         { "media_ui_right", "UI Right %; 90|70|80|100" },
         { "media_viz_bands", "Viz Bands; 40|20" },
-        { "media_viz_mode", "Viz Mode; Bars|VU Meter|Dots|Line|Scope|Mirror" },
+        { "media_viz_mode", "Viz Mode; Bars|VU Meter|Dots|Line|Scope|Mirror|Horizon" },
         { "media_viz_gradient", "Viz Gradient; On|Off" },
         { "media_viz_peak_hold", "Peak Hold; 30|0|15|45|60" },
         { "media_use_filename", "Track Text Mode; Show ID|Show filename with extension|Show Filename without extension" },

--- a/src/config.c
+++ b/src/config.c
@@ -80,14 +80,7 @@ void config_update(retro_environment_t environ_cb) {
     cfg.show_bar = get_bool_var(environ_cb, "media_show_bar", true);
     cfg.show_tim = get_bool_var(environ_cb, "media_show_tim", true);
     cfg.show_ico = get_bool_var(environ_cb, "media_show_ico", true);
-    cfg.responsive = get_bool_var(environ_cb, "media_responsive", true);
     cfg.debug_layout = get_bool_var(environ_cb, "media_debug_layout", false);
-    cfg.art_y = get_int_var(environ_cb, "media_art_y", 40, -4096, 4096);
-    cfg.txt_y = get_int_var(environ_cb, "media_txt_y", 150, -4096, 4096);
-    cfg.viz_y = get_int_var(environ_cb, "media_viz_y", 140, -4096, 4096);
-    cfg.bar_y = get_int_var(environ_cb, "media_bar_y", 180, -4096, 4096);
-    cfg.tim_y = get_int_var(environ_cb, "media_tim_y", 190, -4096, 4096);
-    cfg.ico_y = get_int_var(environ_cb, "media_ico_y", 20, -4096, 4096);
     cfg.ui_top = get_int_var(environ_cb, "media_ui_top", 20, 0, 100);
     cfg.ui_bottom = get_int_var(environ_cb, "media_ui_bottom", 80, 0, 100);
     cfg.ui_left = get_int_var(environ_cb, "media_ui_left", 10, 0, 100);
@@ -122,15 +115,11 @@ void config_declare_variables(retro_environment_t cb) {
         { "media_show_art", "Show Art; On|Off" }, { "media_show_txt", "Show Scroll Text; On|Off" },
         { "media_show_viz", "Show Visualizer; On|Off" }, { "media_show_bar", "Show Progress Bar; On|Off" },
         { "media_show_tim", "Show Time; On|Off" }, { "media_show_ico", "Show Transport Icons; On|Off" },
-        { "media_responsive", "Responsive Layout; On|Off" },
         { "media_debug_layout", "Debug Layout Bounds; Off|On" },
         { "media_ui_top", "UI Top %; 20|0|10|30|40|50" },
         { "media_ui_bottom", "UI Bottom %; 80|50|60|70|90|100" },
         { "media_ui_left", "UI Left %; 10|0|20|30" },
         { "media_ui_right", "UI Right %; 90|70|80|100" },
-        { "media_art_y", "Art Y; 40|0|80|120" }, { "media_txt_y", "Text Y; 150|20|120|200" },
-        { "media_viz_y", "Viz Y; 140|80|200" }, { "media_bar_y", "Bar Y; 180|100|210" },
-        { "media_tim_y", "Time Y; 190|110|220" }, { "media_ico_y", "Icon Y; 20|50|200" },
         { "media_viz_bands", "Viz Bands; 40|20" },
         { "media_viz_mode", "Viz Mode; Bars|VU Meter|Dots|Line" },
         { "media_viz_gradient", "Viz Gradient; On|Off" },

--- a/src/config.h
+++ b/src/config.h
@@ -24,6 +24,7 @@ typedef enum {
 // Configuration structure for all UI and display options
 typedef struct {
     uint16_t bg_rgb, fg_rgb;
+    int ui_scale;   // 1 = 320x240, 2 = 640x480
     int ui_top, ui_bottom, ui_left, ui_right;
     bool show_art, show_txt, show_viz, show_bar, show_tim, show_ico;
     bool debug_layout;

--- a/src/config.h
+++ b/src/config.h
@@ -21,10 +21,9 @@ typedef enum {
 // Configuration structure for all UI and display options
 typedef struct {
     uint16_t bg_rgb, fg_rgb;
-    int art_y, txt_y, viz_y, bar_y, tim_y, ico_y;
     int ui_top, ui_bottom, ui_left, ui_right;
     bool show_art, show_txt, show_viz, show_bar, show_tim, show_ico;
-    bool responsive, debug_layout;
+    bool debug_layout;
     int viz_bands, viz_mode, viz_peak_hold;
     bool viz_gradient;
     TrackTextMode track_text_mode;

--- a/src/config.h
+++ b/src/config.h
@@ -24,7 +24,7 @@ typedef enum {
 // Configuration structure for all UI and display options
 typedef struct {
     uint16_t bg_rgb, fg_rgb;
-    int ui_scale;   // 1 = 320x240, 2 = 640x480
+    int ui_scale;   // resolution scale: framebuffer = 320x240 * ui_scale (1-4)
     int ui_top, ui_bottom, ui_left, ui_right;
     bool show_art, show_txt, show_viz, show_bar, show_tim, show_ico;
     bool debug_layout;

--- a/src/config.h
+++ b/src/config.h
@@ -15,7 +15,8 @@ typedef enum {
     VIZ_MODE_DOTS = 1,
     VIZ_MODE_LINE = 2,
     VIZ_MODE_VU = 3,
-    VIZ_MODE_FFT_EQ_LEGACY = 4
+    VIZ_MODE_FFT_EQ_LEGACY = 4,
+    VIZ_MODE_SCOPE = 5
 } VizMode;
 
 // Configuration structure for all UI and display options

--- a/src/config.h
+++ b/src/config.h
@@ -17,7 +17,8 @@ typedef enum {
     VIZ_MODE_VU = 3,
     VIZ_MODE_FFT_EQ_LEGACY = 4,
     VIZ_MODE_SCOPE = 5,
-    VIZ_MODE_MIRROR = 6
+    VIZ_MODE_MIRROR = 6,
+    VIZ_MODE_HORIZON = 7
 } VizMode;
 
 // Configuration structure for all UI and display options

--- a/src/config.h
+++ b/src/config.h
@@ -16,7 +16,8 @@ typedef enum {
     VIZ_MODE_LINE = 2,
     VIZ_MODE_VU = 3,
     VIZ_MODE_FFT_EQ_LEGACY = 4,
-    VIZ_MODE_SCOPE = 5
+    VIZ_MODE_SCOPE = 5,
+    VIZ_MODE_MIRROR = 6
 } VizMode;
 
 // Configuration structure for all UI and display options

--- a/src/core.c
+++ b/src/core.c
@@ -1138,7 +1138,8 @@ bool retro_unserialize(const void *d, size_t s) {
     metadata_load(tracks[current_idx], m3u_base_path, cfg.track_text_mode);
     is_paused = state->is_paused != 0;
     is_shuffle = state->is_shuffle != 0;
-    int min_scroll_x = -((int)strlen(display_str) * GLYPH_WIDTH);
+    int restored_scale = (layout.text_scale > 0) ? layout.text_scale : 1;
+    int min_scroll_x = -((int)strlen(display_str) * GLYPH_WIDTH * restored_scale);
     scroll_x = state->scroll_x;
     if (scroll_x < min_scroll_x || scroll_x > FB_WIDTH) scroll_x = FB_WIDTH;
     ff_rw_icon_timer = state->ff_rw_icon_timer;

--- a/src/core.c
+++ b/src/core.c
@@ -731,17 +731,23 @@ static void apply_config_update(void) {
 
 static void refresh_config_and_layout(void) {
     TrackTextMode old_track_text_mode = cfg.track_text_mode;
+    bool old_show_txt = cfg.show_txt;
     apply_config_update();
     layout_compute();
 
-    if (old_track_text_mode != cfg.track_text_mode &&
-        track_count > 0 &&
+    if (track_count > 0 &&
         current_idx >= 0 &&
         current_idx < track_count &&
         tracks[current_idx]) {
-        metadata_refresh_display(tracks[current_idx], cfg.track_text_mode);
-        scroll_x = layout.text.x;
-        ui_reset_marquee();
+        if (old_track_text_mode != cfg.track_text_mode)
+            metadata_refresh_display(tracks[current_idx], cfg.track_text_mode);
+        // Restart the marquee when the text mode changes or the title is
+        // re-enabled, so it never resumes from a stale mid-scroll position.
+        if (old_track_text_mode != cfg.track_text_mode ||
+            (cfg.show_txt && !old_show_txt)) {
+            scroll_x = layout.text.x;
+            ui_reset_marquee();
+        }
     }
 }
 

--- a/src/core.c
+++ b/src/core.c
@@ -115,7 +115,8 @@ static int next_viz_mode(int mode) {
     if (mode == VIZ_MODE_VU) return VIZ_MODE_DOTS;                                     // VU Meter -> Dots
     if (mode == VIZ_MODE_DOTS) return VIZ_MODE_LINE;                                   // Dots -> Line
     if (mode == VIZ_MODE_LINE) return VIZ_MODE_SCOPE;                                  // Line -> Scope
-    return VIZ_MODE_BARS;                                                               // Scope/unknown -> Bars
+    if (mode == VIZ_MODE_SCOPE) return VIZ_MODE_MIRROR;                                // Scope -> Mirror
+    return VIZ_MODE_BARS;                                                               // Mirror/unknown -> Bars
 }
 
 static int is_valid_viz_mode(int mode) {
@@ -124,7 +125,8 @@ static int is_valid_viz_mode(int mode) {
            mode == VIZ_MODE_VU ||
            mode == VIZ_MODE_DOTS ||
            mode == VIZ_MODE_LINE ||
-           mode == VIZ_MODE_SCOPE;
+           mode == VIZ_MODE_SCOPE ||
+           mode == VIZ_MODE_MIRROR;
 }
 
 static int normalize_viz_mode(int mode) {

--- a/src/core.c
+++ b/src/core.c
@@ -116,7 +116,8 @@ static int next_viz_mode(int mode) {
     if (mode == VIZ_MODE_DOTS) return VIZ_MODE_LINE;                                   // Dots -> Line
     if (mode == VIZ_MODE_LINE) return VIZ_MODE_SCOPE;                                  // Line -> Scope
     if (mode == VIZ_MODE_SCOPE) return VIZ_MODE_MIRROR;                                // Scope -> Mirror
-    return VIZ_MODE_BARS;                                                               // Mirror/unknown -> Bars
+    if (mode == VIZ_MODE_MIRROR) return VIZ_MODE_HORIZON;                              // Mirror -> Horizon
+    return VIZ_MODE_BARS;                                                               // Horizon/unknown -> Bars
 }
 
 static int is_valid_viz_mode(int mode) {
@@ -126,7 +127,8 @@ static int is_valid_viz_mode(int mode) {
            mode == VIZ_MODE_DOTS ||
            mode == VIZ_MODE_LINE ||
            mode == VIZ_MODE_SCOPE ||
-           mode == VIZ_MODE_MIRROR;
+           mode == VIZ_MODE_MIRROR ||
+           mode == VIZ_MODE_HORIZON;
 }
 
 static int normalize_viz_mode(int mode) {

--- a/src/core.c
+++ b/src/core.c
@@ -702,7 +702,7 @@ static bool open_track(int idx) {
 
     // Load metadata and album art
     metadata_load(p, m3u_base_path, cfg.track_text_mode);
-    scroll_x = cfg.responsive ? layout.text.x : FB_WIDTH;
+    scroll_x = layout.text.x;
     ui_reset_marquee();
     return true;
 }
@@ -726,8 +726,7 @@ static void apply_config_update(void) {
 static void refresh_config_and_layout(void) {
     TrackTextMode old_track_text_mode = cfg.track_text_mode;
     apply_config_update();
-    if (cfg.responsive)
-        layout_compute();
+    layout_compute();
 
     if (old_track_text_mode != cfg.track_text_mode &&
         track_count > 0 &&
@@ -735,7 +734,7 @@ static void refresh_config_and_layout(void) {
         current_idx < track_count &&
         tracks[current_idx]) {
         metadata_refresh_display(tracks[current_idx], cfg.track_text_mode);
-        scroll_x = cfg.responsive ? layout.text.x : FB_WIDTH;
+        scroll_x = layout.text.x;
         ui_reset_marquee();
     }
 }
@@ -797,7 +796,7 @@ void retro_run(void) {
     if (button_pressed(RETRO_DEVICE_ID_JOYPAD_X)) {
         cfg.viz_mode = next_viz_mode(cfg.viz_mode);
         viz_mode_user_override = true;
-        if (cfg.responsive) layout_compute();
+        layout_compute();
     }
     if (button_pressed(RETRO_DEVICE_ID_JOYPAD_R)) open_next_track();
     if (button_pressed(RETRO_DEVICE_ID_JOYPAD_L)) open_previous_track();
@@ -945,8 +944,7 @@ bool retro_load_game(const struct retro_game_info *g) {
 
     start_shuffle_cycle(generate_shuffle_seed());
     apply_config_update();
-    if (cfg.responsive)
-        layout_compute();
+    layout_compute();
 
     bool opened = open_track(0);
     if (!opened) {
@@ -1129,7 +1127,7 @@ bool retro_unserialize(const void *d, size_t s) {
 
     apply_config_update();
     cfg.viz_mode = normalize_viz_mode(state->viz_mode);
-    if (cfg.responsive) layout_compute();
+    layout_compute();
 
     reset_runtime_state(state->is_shuffle != 0);
     viz_mode_user_override = (cfg.viz_mode != viz_mode_menu_value);

--- a/src/core.c
+++ b/src/core.c
@@ -617,7 +617,7 @@ static void open_previous_track(void) {
 }
 
 static void reset_runtime_state(bool preserve_shuffle_mode) {
-    scroll_x = FB_WIDTH;
+    scroll_x = fb_width;
     held_buttons = 0;
     viz_mode_user_override = false;
     is_paused = false;
@@ -739,7 +739,22 @@ static void apply_config_update(void) {
 static void refresh_config_and_layout(void) {
     TrackTextMode old_track_text_mode = cfg.track_text_mode;
     bool old_show_txt = cfg.show_txt;
+    int old_ui_scale = cfg.ui_scale;
     apply_config_update();
+
+    if (cfg.ui_scale != old_ui_scale) {
+        // Switch within the pre-declared max via SET_GEOMETRY: unlike
+        // SET_SYSTEM_AV_INFO this does not reinitialize the video driver
+        // (which would tear down EmuVR's shared-texture pipeline).
+        video_set_resolution(320 * cfg.ui_scale, 240 * cfg.ui_scale);
+        struct retro_game_geometry geom = {
+            (unsigned)fb_width, (unsigned)fb_height,
+            FB_MAX_WIDTH, FB_MAX_HEIGHT,
+            4.0f / 3.0f
+        };
+        environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &geom);
+    }
+
     layout_compute();
 
     if (track_count > 0 &&
@@ -854,7 +869,7 @@ void retro_run(void) {
         .scroll_x = &scroll_x,
     };
     ui_draw(&frame);
-    video_cb(framebuffer, FB_WIDTH, FB_HEIGHT, FB_WIDTH * 2);
+    video_cb(framebuffer, fb_width, fb_height, fb_width * 2);
 }
 
 void retro_set_environment(retro_environment_t cb) {
@@ -971,6 +986,7 @@ bool retro_load_game(const struct retro_game_info *g) {
 
     start_shuffle_cycle(generate_shuffle_seed());
     apply_config_update();
+    video_set_resolution(320 * cfg.ui_scale, 240 * cfg.ui_scale);
     layout_compute();
 
     bool opened = open_track(0);
@@ -1021,10 +1037,10 @@ void retro_get_system_info(struct retro_system_info *i) {
 void retro_get_system_av_info(struct retro_system_av_info *info) {
     info->timing.fps = 60.0;
     info->timing.sample_rate = (double)OUT_RATE;
-    info->geometry.base_width = FB_WIDTH;
-    info->geometry.base_height = FB_HEIGHT;
-    info->geometry.max_width = FB_WIDTH;
-    info->geometry.max_height = FB_HEIGHT;
+    info->geometry.base_width = fb_width;
+    info->geometry.base_height = fb_height;
+    info->geometry.max_width = FB_MAX_WIDTH;
+    info->geometry.max_height = FB_MAX_HEIGHT;
     info->geometry.aspect_ratio = 4.0 / 3.0;
 }
 void retro_set_audio_sample(retro_audio_sample_t cb) { (void)cb; }
@@ -1168,7 +1184,7 @@ bool retro_unserialize(const void *d, size_t s) {
     int restored_scale = (layout.text_scale > 0) ? layout.text_scale : 1;
     int min_scroll_x = -((int)strlen(display_str) * GLYPH_WIDTH * restored_scale);
     scroll_x = state->scroll_x;
-    if (scroll_x < min_scroll_x || scroll_x > FB_WIDTH) scroll_x = FB_WIDTH;
+    if (scroll_x < min_scroll_x || scroll_x > fb_width) scroll_x = fb_width;
     ff_rw_icon_timer = state->ff_rw_icon_timer;
     if (ff_rw_icon_timer < 0) ff_rw_icon_timer = 0;
     if (ff_rw_icon_timer > SEEK_ICON_FRAMES) ff_rw_icon_timer = SEEK_ICON_FRAMES;

--- a/src/core.c
+++ b/src/core.c
@@ -114,7 +114,8 @@ static int next_viz_mode(int mode) {
     if (mode == VIZ_MODE_BARS || mode == VIZ_MODE_FFT_EQ_LEGACY) return VIZ_MODE_VU; // Bars -> VU Meter
     if (mode == VIZ_MODE_VU) return VIZ_MODE_DOTS;                                     // VU Meter -> Dots
     if (mode == VIZ_MODE_DOTS) return VIZ_MODE_LINE;                                   // Dots -> Line
-    return VIZ_MODE_BARS;                                                               // Line/unknown -> Bars
+    if (mode == VIZ_MODE_LINE) return VIZ_MODE_SCOPE;                                  // Line -> Scope
+    return VIZ_MODE_BARS;                                                               // Scope/unknown -> Bars
 }
 
 static int is_valid_viz_mode(int mode) {
@@ -122,7 +123,8 @@ static int is_valid_viz_mode(int mode) {
            mode == VIZ_MODE_FFT_EQ_LEGACY ||
            mode == VIZ_MODE_VU ||
            mode == VIZ_MODE_DOTS ||
-           mode == VIZ_MODE_LINE;
+           mode == VIZ_MODE_LINE ||
+           mode == VIZ_MODE_SCOPE;
 }
 
 static int normalize_viz_mode(int mode) {

--- a/src/core.c
+++ b/src/core.c
@@ -13,6 +13,7 @@
 #include "config.h"
 #include "layout.h"
 #include "video.h"
+#include "ui.h"
 #include "audio.h"
 #include "metadata.h"
 #include "visualizer.h"
@@ -66,7 +67,6 @@ static bool is_shuffle = false;
 // the user changes the core option itself.
 static bool viz_mode_user_override = false;
 static int viz_mode_menu_value = 0;
-static char time_str[32];
 static int ff_rw_icon_timer = 0;
 static int ff_rw_dir = 0;
 static int seek_repeat_cooldown = 0;
@@ -127,26 +127,6 @@ static int is_valid_viz_mode(int mode) {
 
 static int normalize_viz_mode(int mode) {
     return (mode == VIZ_MODE_FFT_EQ_LEGACY) ? VIZ_MODE_BARS : mode;
-}
-
-static void draw_rect_outline(int x, int y, int w, int h, uint16_t color) {
-    if (w <= 0 || h <= 0) return;
-    int x2 = x + w - 1;
-    int y2 = y + h - 1;
-    for (int px = x; px <= x2; px++) {
-        draw_pixel(px, y, color);
-        draw_pixel(px, y2, color);
-    }
-    for (int py = y; py <= y2; py++) {
-        draw_pixel(x, py, color);
-        draw_pixel(x2, py, color);
-    }
-}
-
-static int playback_progress_width(int width) {
-    if (width <= 0 || total_frames == 0 || cur_frame == 0) return 0;
-    if (cur_frame >= total_frames) return width;
-    return (int)(((double)cur_frame / (double)total_frames) * (double)width);
 }
 
 // Helper function for case-insensitive string comparison
@@ -629,13 +609,13 @@ static void reset_runtime_state(bool preserve_shuffle_mode) {
     viz_mode_user_override = false;
     is_paused = false;
     if (!preserve_shuffle_mode) is_shuffle = false;
-    time_str[0] = '\0';
     ff_rw_icon_timer = 0;
     ff_rw_dir = 0;
     seek_repeat_cooldown = 0;
     config_needs_refresh = true;
     clear_shuffle_state();
     viz_reset_state();
+    ui_reset_marquee();
 }
 
 // Tear down the whole playback session: decoder, artwork, playlist, and
@@ -722,7 +702,8 @@ static bool open_track(int idx) {
 
     // Load metadata and album art
     metadata_load(p, m3u_base_path, cfg.track_text_mode);
-    scroll_x = cfg.responsive ? (layout.content_x + layout.content_w) : FB_WIDTH;
+    scroll_x = cfg.responsive ? layout.text.x : FB_WIDTH;
+    ui_reset_marquee();
     return true;
 }
 
@@ -754,7 +735,8 @@ static void refresh_config_and_layout(void) {
         current_idx < track_count &&
         tracks[current_idx]) {
         metadata_refresh_display(tracks[current_idx], cfg.track_text_mode);
-        scroll_x = cfg.responsive ? (layout.content_x + layout.content_w) : FB_WIDTH;
+        scroll_x = cfg.responsive ? layout.text.x : FB_WIDTH;
+        ui_reset_marquee();
     }
 }
 
@@ -819,6 +801,7 @@ void retro_run(void) {
     }
     if (button_pressed(RETRO_DEVICE_ID_JOYPAD_R)) open_next_track();
     if (button_pressed(RETRO_DEVICE_ID_JOYPAD_L)) open_previous_track();
+    if (ff_rw_icon_timer > 0) ff_rw_icon_timer--;
 
     // 2. Audio Core
     int16_t out_buf[SAMPLES_PER_FRAME * 2] = {0};
@@ -836,101 +819,18 @@ void retro_run(void) {
     audio_batch_cb(out_buf, SAMPLES_PER_FRAME);
 
     // 4. Rendering Section
-    video_clear(cfg.bg_rgb);
-
-    if (cfg.responsive) {
-        if (cfg.show_art && art_buffer && layout.art.w > 0 && layout.art.h > 0) {
-            for (int y = 0; y < layout.art.h; y++) {
-                int src_y = y * art_h_src / layout.art.h;
-                for (int x = 0; x < layout.art.w; x++) {
-                    int src_x = x * art_w_src / layout.art.w;
-                    draw_pixel(layout.art.x + x, layout.art.y + y, art_buffer[src_y * art_w_src + src_x]);
-                }
-            }
-        }
-
-        if (cfg.show_txt && layout.text.w > 0) {
-            int right_edge = layout.text.x + layout.text.w;
-            int text_w = (int)strlen(display_str) * GLYPH_WIDTH;
-            int left_bound = layout.text.x - text_w;
-            if (scroll_x > right_edge || scroll_x < left_bound)
-                scroll_x = right_edge;
-            draw_text_clipped(scroll_x, layout.text.y, display_str, cfg.fg_rgb, layout.text.x, layout.text.w);
-            scroll_x--;
-        }
-
-        if (cfg.show_viz) {
-            viz_draw();
-        }
-
-        if (cfg.show_bar && total_frames > 0 && layout.bar.w > 0) {
-            int filled_w = playback_progress_width(layout.bar.w);
-            for (int w = 0; w < layout.bar.w; w++) draw_pixel(layout.bar.x + w, layout.bar.y, cfg.bg_rgb | 0x18C3);
-            for (int w = 0; w < filled_w; w++) draw_pixel(layout.bar.x + w, layout.bar.y, cfg.fg_rgb);
-        }
-
-        if (cfg.show_tim && layout.time.w > 0) {
-            int sec = source_rate ? (int)(cur_frame / source_rate) : 0;
-            snprintf(time_str, sizeof(time_str), "%02d:%02d", sec / 60, sec % 60);
-            int time_x = layout.time.x + (layout.time.w - ((int)strlen(time_str) * GLYPH_WIDTH)) / 2;
-            draw_text(time_x, layout.time.y, time_str, cfg.fg_rgb);
-        }
-
-        if (cfg.show_ico && layout.icons.w > 0 && layout.icons.h > 0) {
-            if (is_shuffle) draw_text(layout.icon_shuffle_x, layout.icons.y, "SHUF", cfg.fg_rgb);
-            if (is_paused) draw_text(layout.icon_pause_x, layout.icons.y, "||", cfg.fg_rgb);
-            if (ff_rw_icon_timer > 0) {
-                draw_text(layout.icon_seek_x, layout.icons.y, (ff_rw_dir > 0) ? ">>" : "<<", cfg.fg_rgb);
-                ff_rw_icon_timer--;
-            }
-        }
-
-        if (cfg.debug_layout) {
-            // Overlay layout boxes for responsive tuning/debugging.
-            draw_rect_outline(layout.area_x, layout.area_y, layout.area_w, layout.area_h, 0x07FF);
-            draw_rect_outline(layout.content_x, layout.content_y, layout.content_w, layout.content_h, 0x07E0);
-            draw_rect_outline(layout.art.x, layout.art.y, layout.art.w, layout.art.h, 0xFFE0);
-            draw_rect_outline(layout.icons.x, layout.icons.y, layout.icons.w, layout.icons.h, 0xFD20);
-            draw_rect_outline(layout.text.x, layout.text.y, layout.text.w, layout.text.h, 0xF81F);
-            draw_rect_outline(layout.viz.x, layout.viz.y, layout.viz.w, layout.viz.h, 0xF800);
-            draw_rect_outline(layout.bar.x, layout.bar.y, layout.bar.w, layout.bar.h, 0xFFFF);
-            draw_rect_outline(layout.time.x, layout.time.y, layout.time.w, layout.time.h, 0x001F);
-        }
-    } else {
-        if (cfg.show_art && art_buffer) {
-            for (int y = 0; y < 80; y++) {
-                for (int x = 0; x < 80; x++) {
-                    draw_pixel(120 + x, cfg.art_y + y, art_buffer[(y * art_h_src / 80) * art_w_src + (x * art_w_src / 80)]);
-                }
-            }
-        }
-        if (cfg.show_txt) {
-            draw_text(scroll_x, cfg.txt_y, display_str, cfg.fg_rgb);
-            scroll_x--;
-            if (scroll_x < -((int)strlen(display_str) * GLYPH_WIDTH)) scroll_x = FB_WIDTH;
-        }
-        if (cfg.show_viz) {
-            viz_draw();
-        }
-        if (cfg.show_bar && total_frames > 0) {
-            int filled_w = playback_progress_width(200);
-            for (int w = 0; w < 200; w++) draw_pixel(60 + w, cfg.bar_y, cfg.bg_rgb | 0x18C3);
-            for (int w = 0; w < filled_w; w++) draw_pixel(60 + w, cfg.bar_y, cfg.fg_rgb);
-        }
-        if (cfg.show_tim) {
-            int sec = source_rate ? (int)(cur_frame / source_rate) : 0;
-            snprintf(time_str, sizeof(time_str), "%02d:%02d", sec / 60, sec % 60);
-            draw_text(140, cfg.tim_y, time_str, cfg.fg_rgb);
-        }
-        if (cfg.show_ico) {
-            if (is_shuffle) draw_text(20, cfg.ico_y, "SHUF", cfg.fg_rgb);
-            if (is_paused) draw_text(280, cfg.ico_y, "||", cfg.fg_rgb);
-            if (ff_rw_icon_timer > 0) {
-                draw_text(60, cfg.ico_y, (ff_rw_dir > 0) ? ">>" : "<<", cfg.fg_rgb);
-                ff_rw_icon_timer--;
-            }
-        }
-    }
+    UiFrame frame = {
+        .paused = is_paused,
+        .shuffle = is_shuffle,
+        .seek_dir = (ff_rw_icon_timer > 0) ? ff_rw_dir : 0,
+        .track_index = current_idx,
+        .track_count = track_count,
+        .cur_frame = cur_frame,
+        .total_frames = total_frames,
+        .source_rate = source_rate,
+        .scroll_x = &scroll_x,
+    };
+    ui_draw(&frame);
     video_cb(framebuffer, FB_WIDTH, FB_HEIGHT, FB_WIDTH * 2);
 }
 

--- a/src/core.c
+++ b/src/core.c
@@ -70,6 +70,9 @@ static int viz_mode_menu_value = 0;
 static int ff_rw_icon_timer = 0;
 static int ff_rw_dir = 0;
 static int seek_repeat_cooldown = 0;
+// Frame duration reported by the frontend; stays at the 60fps fallback when
+// the frontend does not support the frame-time callback.
+static retro_usec_t frame_time_usec = 1000000 / 60;
 static bool config_needs_refresh = true;
 static uint32_t shuffle_seed = 0;
 static uint32_t shuffle_state = 0;
@@ -98,6 +101,10 @@ static void reset_runtime_state(bool preserve_shuffle_mode);
 static size_t serialized_state_size(void);
 static void open_next_track(void);
 static void open_previous_track(void);
+
+static void frame_time_cb(retro_usec_t usec) {
+    frame_time_usec = usec;
+}
 
 // Edge-triggered button check: true only on the frame the button goes down.
 // Joypad IDs are < 16, so one uint16_t tracks every button's held state.
@@ -752,6 +759,11 @@ static void refresh_config_and_layout(void) {
 }
 
 void retro_run(void) {
+    float dt = (float)frame_time_usec / 1000000.0f;
+    if (dt < 0.001f || dt > 0.1f) dt = 1.0f / 60.0f;  // ignore stalls/garbage
+    ui_set_frame_dt(dt);
+    viz_set_frame_dt(dt);
+
     if (config_needs_refresh) {
         refresh_config_and_layout();
         config_needs_refresh = false;
@@ -953,6 +965,9 @@ bool retro_load_game(const struct retro_game_info *g) {
         unload_session();
         return false;
     }
+
+    struct retro_frame_time_callback ftcb = { frame_time_cb, 1000000 / 60 };
+    environ_cb(RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK, &ftcb);
 
     start_shuffle_cycle(generate_shuffle_seed());
     apply_config_update();

--- a/src/core.c
+++ b/src/core.c
@@ -73,6 +73,9 @@ static int seek_repeat_cooldown = 0;
 // Frame duration reported by the frontend; stays at the 60fps fallback when
 // the frontend does not support the frame-time callback.
 static retro_usec_t frame_time_usec = 1000000 / 60;
+// A resolution change happened outside retro_run; SET_GEOMETRY is only legal
+// from within retro_run, so the notification is deferred to the next frame.
+static bool geometry_dirty = false;
 static bool config_needs_refresh = true;
 static uint32_t shuffle_seed = 0;
 static uint32_t shuffle_state = 0;
@@ -104,6 +107,16 @@ static void open_previous_track(void);
 
 static void frame_time_cb(retro_usec_t usec) {
     frame_time_usec = usec;
+}
+
+// Apply the configured resolution to the framebuffer wherever config is
+// re-read (run/reset/unserialize); the frontend learns about it on the next
+// retro_run via SET_GEOMETRY.
+static void apply_resolution_from_config(void) {
+    int scale = (cfg.ui_scale > 0) ? cfg.ui_scale : 1;
+    if (320 * scale == fb_width) return;
+    video_set_resolution(320 * scale, 240 * scale);
+    geometry_dirty = true;
 }
 
 // Edge-triggered button check: true only on the frame the button goes down.
@@ -742,19 +755,7 @@ static void refresh_config_and_layout(void) {
     int old_ui_scale = cfg.ui_scale;
     apply_config_update();
 
-    if (cfg.ui_scale != old_ui_scale) {
-        // Switch within the pre-declared max via SET_GEOMETRY: unlike
-        // SET_SYSTEM_AV_INFO this does not reinitialize the video driver
-        // (which would tear down EmuVR's shared-texture pipeline).
-        video_set_resolution(320 * cfg.ui_scale, 240 * cfg.ui_scale);
-        struct retro_game_geometry geom = {
-            (unsigned)fb_width, (unsigned)fb_height,
-            FB_MAX_WIDTH, FB_MAX_HEIGHT,
-            4.0f / 3.0f
-        };
-        environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &geom);
-    }
-
+    apply_resolution_from_config();
     layout_compute();
 
     if (track_count > 0 &&
@@ -763,10 +764,12 @@ static void refresh_config_and_layout(void) {
         tracks[current_idx]) {
         if (old_track_text_mode != cfg.track_text_mode)
             metadata_refresh_display(tracks[current_idx], cfg.track_text_mode);
-        // Restart the marquee when the text mode changes or the title is
-        // re-enabled, so it never resumes from a stale mid-scroll position.
+        // Restart the marquee when the text mode changes, the title is
+        // re-enabled, or the resolution scale changes, so it never resumes
+        // from a stale or wrong-scale mid-scroll position.
         if (old_track_text_mode != cfg.track_text_mode ||
-            (cfg.show_txt && !old_show_txt)) {
+            (cfg.show_txt && !old_show_txt) ||
+            cfg.ui_scale != old_ui_scale) {
             scroll_x = layout.text.x;
             ui_reset_marquee();
         }
@@ -787,6 +790,19 @@ void retro_run(void) {
         if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
             refresh_config_and_layout();
     }
+
+    if (geometry_dirty) {
+        // Within the pre-declared max, SET_GEOMETRY changes size without a
+        // driver reinit (which would tear down EmuVR's shared-texture pipe).
+        struct retro_game_geometry geom = {
+            (unsigned)fb_width, (unsigned)fb_height,
+            FB_MAX_WIDTH, FB_MAX_HEIGHT,
+            4.0f / 3.0f
+        };
+        environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &geom);
+        geometry_dirty = false;
+    }
+
     input_poll_cb();
 
     // 1. Handle Inputs
@@ -986,7 +1002,10 @@ bool retro_load_game(const struct retro_game_info *g) {
 
     start_shuffle_cycle(generate_shuffle_seed());
     apply_config_update();
+    // The frontend queries retro_get_system_av_info after load, so the base
+    // size is declared there; no SET_GEOMETRY needed for this change.
     video_set_resolution(320 * cfg.ui_scale, 240 * cfg.ui_scale);
+    geometry_dirty = false;
     layout_compute();
 
     bool opened = open_track(0);
@@ -1170,6 +1189,7 @@ bool retro_unserialize(const void *d, size_t s) {
 
     apply_config_update();
     cfg.viz_mode = normalize_viz_mode(state->viz_mode);
+    apply_resolution_from_config();
     layout_compute();
 
     reset_runtime_state(state->is_shuffle != 0);
@@ -1181,7 +1201,8 @@ bool retro_unserialize(const void *d, size_t s) {
     metadata_load(tracks[current_idx], m3u_base_path, cfg.track_text_mode);
     is_paused = state->is_paused != 0;
     is_shuffle = state->is_shuffle != 0;
-    int restored_scale = (layout.text_scale > 0) ? layout.text_scale : 1;
+    int restored_scale = ((layout.text_scale > 0) ? layout.text_scale : 1)
+                       * ((cfg.ui_scale > 0) ? cfg.ui_scale : 1);
     int min_scroll_x = -((int)strlen(display_str) * GLYPH_WIDTH * restored_scale);
     scroll_x = state->scroll_x;
     if (scroll_x < min_scroll_x || scroll_x > fb_width) scroll_x = fb_width;

--- a/src/layout.c
+++ b/src/layout.c
@@ -82,7 +82,8 @@ static void place_art(void) {
         int max_side = layout.area_w - frame_inset - gap_after_art - 48;
         if (max_side < 0) max_side = 0;
         if (art_side > max_side) art_side = max_side;
-        if (art_side > layout.area_h - frame_inset) art_side = layout.area_h - frame_inset;
+        // Reserve the frame inset above plus frame + drop shadow (4px) below.
+        if (art_side > layout.area_h - frame_inset - 4) art_side = layout.area_h - frame_inset - 4;
         if (art_side > 0) {
             // Top-aligned so the art frame's top edge lines up with the
             // visualizer panel's top edge instead of floating mid-column.
@@ -95,7 +96,8 @@ static void place_art(void) {
         int max_side = layout.area_h - frame_inset - gap_after_art - 56;
         if (max_side < 0) max_side = 0;
         if (art_side > max_side) art_side = max_side;
-        if (art_side > layout.area_w - frame_inset * 2) art_side = layout.area_w - frame_inset * 2;
+        // Frame on both sides plus the drop shadow's 2px to the right.
+        if (art_side > layout.area_w - frame_inset * 2 - 2) art_side = layout.area_w - frame_inset * 2 - 2;
         if (art_side > 0) {
             layout.art.x = layout.area_x + (layout.area_w - art_side) / 2;
             layout.art.y = layout.area_y + frame_inset;

--- a/src/layout.c
+++ b/src/layout.c
@@ -4,6 +4,9 @@
 
 Layout layout;
 
+// Sunken panel border + padding around the visualizer's drawing region.
+#define VIZ_PANEL_PAD 4
+
 static int clamp_i(int value, int lo, int hi) {
     if (value < lo) return lo;
     if (value > hi) return hi;
@@ -17,6 +20,100 @@ static int min_i(int a, int b) {
 static Rect zero_rect(void) {
     Rect r = {0, 0, 0, 0};
     return r;
+}
+
+static void reset_viz_geometry(void) {
+    layout.viz_max_h = 0;
+    layout.viz_spacing = 0;
+    layout.viz_start_x = layout.content_x;
+    layout.viz_bar_width = 0;
+    layout.viz_meter_w = 0;
+}
+
+// Bar/meter geometry is derived from the panel interior, not the panel rect.
+static void compute_viz_geometry(void) {
+    if (layout.viz_inner.w <= 0 || layout.viz_inner.h <= 0) {
+        reset_viz_geometry();
+        return;
+    }
+
+    layout.viz_max_h = layout.viz_inner.h;
+
+    int bands = (cfg.viz_bands > 0) ? cfg.viz_bands : 40;
+    int spacing = layout.viz_inner.w / bands;
+    if (spacing < 1) spacing = 1;
+    layout.viz_spacing = spacing;
+
+    int bars_w = spacing * bands;
+    layout.viz_start_x = layout.viz_inner.x + (layout.viz_inner.w - bars_w) / 2;
+
+    int bar_width = spacing - 1;
+    if (bar_width < 1) bar_width = 1;
+    if (bar_width > 4) bar_width = 4;
+    layout.viz_bar_width = bar_width;
+
+    layout.viz_meter_w = layout.viz_inner.w - 16;
+    if (layout.viz_meter_w < 8) layout.viz_meter_w = layout.viz_inner.w;
+    if (layout.viz_meter_w < 1) layout.viz_meter_w = 1;
+}
+
+static void compute_viz_inner(void) {
+    layout.viz_inner = zero_rect();
+    if (layout.viz.w <= 0 || layout.viz.h <= 0) return;
+
+    int pad = VIZ_PANEL_PAD;
+    if (layout.viz.w <= pad * 2 + 2 || layout.viz.h <= pad * 2 + 2) pad = 1;
+    layout.viz_inner.x = layout.viz.x + pad;
+    layout.viz_inner.y = layout.viz.y + pad;
+    layout.viz_inner.w = layout.viz.w - pad * 2;
+    layout.viz_inner.h = layout.viz.h - pad * 2;
+    if (layout.viz_inner.w < 1 || layout.viz_inner.h < 1) layout.viz_inner = zero_rect();
+}
+
+static void place_art(void) {
+    const int gap_after_art = 4;
+    if (!cfg.show_art) return;
+
+    int art_side = min_i(layout.area_w, layout.area_h) * 40 / 100;
+    art_side = clamp_i(art_side, 32, 120);
+
+    if (layout.is_wide) {
+        int max_side = layout.area_w - gap_after_art - 48;
+        if (max_side < 0) max_side = 0;
+        if (art_side > max_side) art_side = max_side;
+        if (art_side > layout.area_h) art_side = layout.area_h;
+        if (art_side > 0) {
+            layout.art.x = layout.area_x;
+            layout.art.y = layout.area_y + (layout.area_h - art_side) / 2;
+            layout.art.w = art_side;
+            layout.art.h = art_side;
+        }
+    } else {
+        int max_side = layout.area_h - gap_after_art - 56;
+        if (max_side < 0) max_side = 0;
+        if (art_side > max_side) art_side = max_side;
+        if (art_side > layout.area_w) art_side = layout.area_w;
+        if (art_side > 0) {
+            layout.art.x = layout.area_x + (layout.area_w - art_side) / 2;
+            layout.art.y = layout.area_y;
+            layout.art.w = art_side;
+            layout.art.h = art_side;
+        }
+    }
+
+    if (layout.art.w > 0 && layout.art.h > 0) {
+        if (layout.is_wide) {
+            layout.content_x = layout.art.x + layout.art.w + gap_after_art;
+            layout.content_y = layout.area_y;
+            layout.content_w = (layout.area_x + layout.area_w) - layout.content_x;
+            layout.content_h = layout.area_h;
+        } else {
+            layout.content_x = layout.area_x;
+            layout.content_y = layout.art.y + layout.art.h + gap_after_art;
+            layout.content_w = layout.area_w;
+            layout.content_h = (layout.area_y + layout.area_h) - layout.content_y;
+        }
+    }
 }
 
 void layout_compute(void) {
@@ -51,6 +148,8 @@ void layout_compute(void) {
     layout.viz = zero_rect();
     layout.bar = zero_rect();
     layout.time = zero_rect();
+    layout.viz_inner = zero_rect();
+    layout.text_scale = 1;
 
     layout.content_x = layout.area_x;
     layout.content_y = layout.area_y;
@@ -58,6 +157,7 @@ void layout_compute(void) {
     layout.content_h = layout.area_h;
 
     if (layout.area_w <= 0 || layout.area_h <= 0) {
+        reset_viz_geometry();
         layout.viz_start_x = 0;
         layout.viz_bar_width = 1;
         layout.viz_spacing = 1;
@@ -69,103 +169,69 @@ void layout_compute(void) {
         return;
     }
 
-    const int gap_after_art = 4;
-    if (cfg.show_art) {
-        int art_side = min_i(layout.area_w, layout.area_h) * 40 / 100;
-        art_side = clamp_i(art_side, 32, 120);
-
-        if (layout.is_wide) {
-            int max_side = layout.area_w - gap_after_art - 48;
-            if (max_side < 0) max_side = 0;
-            if (art_side > max_side) art_side = max_side;
-            if (art_side > layout.area_h) art_side = layout.area_h;
-            if (art_side > 0) {
-                layout.art.x = layout.area_x;
-                layout.art.y = layout.area_y + (layout.area_h - art_side) / 2;
-                layout.art.w = art_side;
-                layout.art.h = art_side;
-            }
-        } else {
-            int max_side = layout.area_h - gap_after_art - 56;
-            if (max_side < 0) max_side = 0;
-            if (art_side > max_side) art_side = max_side;
-            if (art_side > layout.area_w) art_side = layout.area_w;
-            if (art_side > 0) {
-                layout.art.x = layout.area_x + (layout.area_w - art_side) / 2;
-                layout.art.y = layout.area_y;
-                layout.art.w = art_side;
-                layout.art.h = art_side;
-            }
-        }
-    }
-
-    if (cfg.show_art && layout.art.w > 0 && layout.art.h > 0) {
-        if (layout.is_wide) {
-            layout.content_x = layout.art.x + layout.art.w + gap_after_art;
-            layout.content_y = layout.area_y;
-            layout.content_w = (layout.area_x + layout.area_w) - layout.content_x;
-            layout.content_h = layout.area_h;
-        } else {
-            layout.content_x = layout.area_x;
-            layout.content_y = layout.art.y + layout.art.h + gap_after_art;
-            layout.content_w = layout.area_w;
-            layout.content_h = (layout.area_y + layout.area_h) - layout.content_y;
-        }
-    }
+    place_art();
 
     if (layout.content_w < 1) layout.content_w = 1;
     if (layout.content_h < 1) layout.content_h = 1;
 
-    const int icons_h = 8;
-    const int text_h = 8;
-    const int bar_h = 1;
+    const int transport_h = 12;
+    const int bar_h = 8;
     const int time_h = 8;
-    const int viz_min_h = 16;
+    const int cluster_gap = 2;
+    const int viz_min_h = 20;                       // 12px of drawing inside the panel
+    const int vu_compact_h = 16 + 2 * VIZ_PANEL_PAD;
 
-    const int use_icons = cfg.show_ico ? 1 : 0;
     const int use_viz = cfg.show_viz ? 1 : 0;
     const int use_text = cfg.show_txt ? 1 : 0;
     const int use_bar = cfg.show_bar ? 1 : 0;
     const int use_time = cfg.show_tim ? 1 : 0;
-    const int blocks = use_icons + use_viz + use_text + use_bar + use_time;
+    int use_transport = cfg.show_ico ? 1 : 0;
 
-    int fixed_h = 0;
-    if (use_icons) fixed_h += icons_h;
-    if (use_viz) fixed_h += viz_min_h;
-    if (use_text) fixed_h += text_h;
-    if (use_bar) fixed_h += bar_h;
-    if (use_time) fixed_h += time_h;
-
+    int text_scale = use_text ? 2 : 1;
     int viz_h = use_viz ? viz_min_h : 0;
+    int cluster_h = 0;
+    int fixed_h = 0;
+
+    // Fit pass. On short screens the transport row vanishes first, then the
+    // large title falls back to 1x, then the visualizer panel gives up height.
+    for (;;) {
+        int text_h = use_text ? 8 * text_scale : 0;
+        int members = use_text + use_bar + use_time;
+        cluster_h = text_h + (use_bar ? bar_h : 0) + (use_time ? time_h : 0);
+        if (members > 1) cluster_h += (members - 1) * cluster_gap;
+        fixed_h = viz_h + cluster_h + (use_transport ? transport_h : 0);
+        if (fixed_h <= layout.content_h) break;
+        if (use_transport) { use_transport = 0; continue; }
+        if (text_scale == 2) { text_scale = 1; continue; }
+        break;
+    }
+
     if (use_viz && fixed_h > layout.content_h) {
         viz_h -= (fixed_h - layout.content_h);
-        if (viz_h < 4) viz_h = 4;
-        fixed_h = (use_icons ? icons_h : 0) + (use_text ? text_h : 0) +
-                  (use_bar ? bar_h : 0) + (use_time ? time_h : 0) + viz_h;
+        if (viz_h < 12) viz_h = 12;
+        fixed_h = viz_h + cluster_h;
     }
 
-    if (use_viz && cfg.viz_mode == VIZ_MODE_VU) {
-        // VU meter includes 8px text labels; reserve a slightly taller compact block.
-        const int vu_compact_h = 16;
-        if (viz_h > vu_compact_h) {
-            fixed_h -= (viz_h - vu_compact_h);
-            viz_h = vu_compact_h;
-        }
+    if (use_viz && cfg.viz_mode == VIZ_MODE_VU && viz_h > vu_compact_h) {
+        // Keep VU mode compact instead of inflating its internal blank space.
+        fixed_h -= (viz_h - vu_compact_h);
+        viz_h = vu_compact_h;
     }
 
-    int gap = 0;
-    const int gap_count = (blocks > 1) ? (blocks - 1) : 0;
+    const int has_cluster = (use_text + use_bar + use_time) > 0 ? 1 : 0;
+    const int groups = use_viz + has_cluster + use_transport;
+    const int gap_count = (groups > 1) ? (groups - 1) : 0;
+    int group_gap = 0;
     if (gap_count > 0 && layout.content_h > fixed_h) {
-        gap = (layout.content_h - fixed_h) / gap_count;
-        if (gap > 8) gap = 8;
+        group_gap = (layout.content_h - fixed_h) / gap_count;
+        if (group_gap > 8) group_gap = 8;
     }
 
-    int used_h = fixed_h + (gap * gap_count);
+    int used_h = fixed_h + (group_gap * gap_count);
     int surplus = layout.content_h - used_h;
     int y = layout.content_y;
     if (use_viz) {
         if (cfg.viz_mode == VIZ_MODE_VU) {
-            // Center the full stack instead of inflating VU mode's internal blank space.
             if (surplus > 0) y += surplus / 2;
         } else {
             viz_h += surplus;
@@ -175,28 +241,23 @@ void layout_compute(void) {
     }
     if (use_viz && viz_h < 1) viz_h = 1;
 
-    if (use_icons) {
-        layout.icons.x = layout.content_x;
-        layout.icons.y = y;
-        layout.icons.w = layout.content_w;
-        layout.icons.h = icons_h;
-        y += icons_h + gap;
-    }
-
     if (use_viz) {
         layout.viz.x = layout.content_x;
         layout.viz.y = y;
         layout.viz.w = layout.content_w;
         layout.viz.h = viz_h;
-        y += viz_h + gap;
+        y += viz_h;
+        if (has_cluster || use_transport) y += group_gap;
     }
 
     if (use_text) {
         layout.text.x = layout.content_x;
         layout.text.y = y;
         layout.text.w = layout.content_w;
-        layout.text.h = text_h;
-        y += text_h + gap;
+        layout.text.h = 8 * text_scale;
+        layout.text_scale = text_scale;
+        y += layout.text.h;
+        if (use_bar || use_time) y += cluster_gap;
     }
 
     if (use_bar) {
@@ -206,7 +267,8 @@ void layout_compute(void) {
         layout.bar.h = bar_h;
         layout.bar.x = layout.content_x + (layout.content_w - bar_w) / 2;
         layout.bar.y = y;
-        y += bar_h + gap;
+        y += bar_h;
+        if (use_time) y += cluster_gap;
     }
 
     if (use_time) {
@@ -214,56 +276,41 @@ void layout_compute(void) {
         layout.time.y = y;
         layout.time.w = layout.content_w;
         layout.time.h = time_h;
+        y += time_h;
     }
 
-    // Hide elements that overflow the content boundary
+    if (use_transport) {
+        if (has_cluster) y += group_gap;
+        layout.icons.x = layout.content_x;
+        layout.icons.y = y;
+        layout.icons.w = layout.content_w;
+        layout.icons.h = transport_h;
+    }
+
+    // Hide elements that overflow the content boundary, bottom-most first.
     int bottom = layout.content_y + layout.content_h;
+    if (layout.icons.h > 0 && layout.icons.y + layout.icons.h > bottom) layout.icons = zero_rect();
     if (layout.time.h > 0 && layout.time.y + layout.time.h > bottom) layout.time = zero_rect();
     if (layout.bar.h > 0 && layout.bar.y + layout.bar.h > bottom) layout.bar = zero_rect();
     if (layout.text.h > 0 && layout.text.y + layout.text.h > bottom) layout.text = zero_rect();
     if (layout.viz.h > 0 && layout.viz.y + layout.viz.h > bottom) layout.viz = zero_rect();
-    if (layout.icons.h > 0 && layout.icons.y + layout.icons.h > bottom) layout.icons = zero_rect();
 
     if (layout.icons.w > 0) {
-        layout.icon_shuffle_x = layout.icons.x;
-        layout.icon_pause_x = layout.icons.x + layout.icons.w - 16;
-        if (layout.icon_pause_x < layout.icons.x) layout.icon_pause_x = layout.icons.x;
-
-        int seek_x = layout.icons.x + layout.icons.w / 3;
-        if (seek_x < layout.icons.x + 40) seek_x = layout.icons.x + 40;
-        if (seek_x > layout.icon_pause_x - 16) seek_x = layout.icon_pause_x - 16;
-        if (seek_x < layout.icons.x) seek_x = layout.icons.x;
-        layout.icon_seek_x = seek_x;
+        // Transport anchors: prev / play-pause / next trio around the center,
+        // shuffle to the right of the trio.
+        int center = layout.icons.x + layout.icons.w / 2;
+        layout.icon_pause_x = center - 5;
+        layout.icon_seek_x = layout.icon_pause_x - 24;
+        layout.icon_shuffle_x = layout.icon_pause_x + 48;
+        if (layout.icon_seek_x < layout.icons.x) layout.icon_seek_x = layout.icons.x;
+        if (layout.icon_shuffle_x + 10 > layout.icons.x + layout.icons.w)
+            layout.icon_shuffle_x = layout.icons.x + layout.icons.w - 10;
     } else {
         layout.icon_shuffle_x = layout.content_x;
         layout.icon_seek_x = layout.content_x;
         layout.icon_pause_x = layout.content_x;
     }
 
-    if (layout.viz.w > 0 && layout.viz.h > 0) {
-        layout.viz_max_h = layout.viz.h;
-
-        int bands = (cfg.viz_bands > 0) ? cfg.viz_bands : 40;
-        int spacing = layout.viz.w / bands;
-        if (spacing < 1) spacing = 1;
-        layout.viz_spacing = spacing;
-
-        int bars_w = spacing * bands;
-        layout.viz_start_x = layout.viz.x + (layout.viz.w - bars_w) / 2;
-
-        int bar_width = spacing - 1;
-        if (bar_width < 1) bar_width = 1;
-        if (bar_width > 4) bar_width = 4;
-        layout.viz_bar_width = bar_width;
-
-        layout.viz_meter_w = layout.viz.w - 16;
-        if (layout.viz_meter_w < 8) layout.viz_meter_w = layout.viz.w;
-        if (layout.viz_meter_w < 1) layout.viz_meter_w = 1;
-    } else {
-        layout.viz_max_h = 0;
-        layout.viz_spacing = 0;
-        layout.viz_start_x = layout.content_x;
-        layout.viz_bar_width = 0;
-        layout.viz_meter_w = 0;
-    }
+    compute_viz_inner();
+    compute_viz_geometry();
 }

--- a/src/layout.c
+++ b/src/layout.c
@@ -211,8 +211,11 @@ void layout_compute(void) {
     }
 
     if (use_viz && fixed_h > layout.content_h) {
+        // VU never shrinks below two meter rows (no mono fallback); the
+        // overflow guards drop other elements instead.
+        int viz_floor = (cfg.viz_mode == VIZ_MODE_VU) ? vu_compact_h : 12;
         viz_h -= (fixed_h - layout.content_h);
-        if (viz_h < 12) viz_h = 12;
+        if (viz_h < viz_floor) viz_h = viz_floor;
         fixed_h = viz_h + cluster_h;
     }
 

--- a/src/layout.c
+++ b/src/layout.c
@@ -71,31 +71,34 @@ static void compute_viz_inner(void) {
 }
 
 static void place_art(void) {
-    const int gap_after_art = 4;
+    const int gap_after_art = 8;   // room for the frame, drop shadow, and breathing space
+    const int frame_inset = 2;     // bevel frame drawn just outside the art rect
     if (!cfg.show_art) return;
 
     int art_side = min_i(layout.area_w, layout.area_h) * 40 / 100;
     art_side = clamp_i(art_side, 32, 120);
 
     if (layout.is_wide) {
-        int max_side = layout.area_w - gap_after_art - 48;
+        int max_side = layout.area_w - frame_inset - gap_after_art - 48;
         if (max_side < 0) max_side = 0;
         if (art_side > max_side) art_side = max_side;
-        if (art_side > layout.area_h) art_side = layout.area_h;
+        if (art_side > layout.area_h - frame_inset) art_side = layout.area_h - frame_inset;
         if (art_side > 0) {
-            layout.art.x = layout.area_x;
-            layout.art.y = layout.area_y + (layout.area_h - art_side) / 2;
+            // Top-aligned so the art frame's top edge lines up with the
+            // visualizer panel's top edge instead of floating mid-column.
+            layout.art.x = layout.area_x + frame_inset;
+            layout.art.y = layout.area_y + frame_inset;
             layout.art.w = art_side;
             layout.art.h = art_side;
         }
     } else {
-        int max_side = layout.area_h - gap_after_art - 56;
+        int max_side = layout.area_h - frame_inset - gap_after_art - 56;
         if (max_side < 0) max_side = 0;
         if (art_side > max_side) art_side = max_side;
-        if (art_side > layout.area_w) art_side = layout.area_w;
+        if (art_side > layout.area_w - frame_inset * 2) art_side = layout.area_w - frame_inset * 2;
         if (art_side > 0) {
             layout.art.x = layout.area_x + (layout.area_w - art_side) / 2;
-            layout.art.y = layout.area_y;
+            layout.art.y = layout.area_y + frame_inset;
             layout.art.w = art_side;
             layout.art.h = art_side;
         }
@@ -261,11 +264,11 @@ void layout_compute(void) {
     }
 
     if (use_bar) {
-        int bar_w = layout.content_w * 80 / 100;
-        if (bar_w < 40) bar_w = layout.content_w;
-        layout.bar.w = bar_w;
+        // Full content width so the bar's left edge lines up with the panel
+        // and title instead of floating centered.
+        layout.bar.w = layout.content_w;
         layout.bar.h = bar_h;
-        layout.bar.x = layout.content_x + (layout.content_w - bar_w) / 2;
+        layout.bar.x = layout.content_x;
         layout.bar.y = y;
         y += bar_h;
         if (use_time) y += cluster_gap;

--- a/src/layout.c
+++ b/src/layout.c
@@ -143,7 +143,6 @@ void layout_compute(void) {
     layout.area_w = x1 - x0;
     layout.area_h = y1 - y0;
     layout.is_wide = (layout.area_w * 3) > (layout.area_h * 4);
-    layout.art_reserves_space = cfg.show_art;
 
     layout.art = zero_rect();
     layout.icons = zero_rect();
@@ -191,7 +190,9 @@ void layout_compute(void) {
     int use_transport = cfg.show_ico ? 1 : 0;
 
     int text_scale = use_text ? 2 : 1;
-    int viz_h = use_viz ? viz_min_h : 0;
+    // VU mode needs a 16px interior (two meter rows + labels); the FFT modes
+    // start from the smaller floor and absorb surplus height later.
+    int viz_h = use_viz ? ((cfg.viz_mode == VIZ_MODE_VU) ? vu_compact_h : viz_min_h) : 0;
     int cluster_h = 0;
     int fixed_h = 0;
 
@@ -215,12 +216,6 @@ void layout_compute(void) {
         fixed_h = viz_h + cluster_h;
     }
 
-    if (use_viz && cfg.viz_mode == VIZ_MODE_VU && viz_h > vu_compact_h) {
-        // Keep VU mode compact instead of inflating its internal blank space.
-        fixed_h -= (viz_h - vu_compact_h);
-        viz_h = vu_compact_h;
-    }
-
     const int has_cluster = (use_text + use_bar + use_time) > 0 ? 1 : 0;
     const int groups = use_viz + has_cluster + use_transport;
     const int gap_count = (groups > 1) ? (groups - 1) : 0;
@@ -236,7 +231,9 @@ void layout_compute(void) {
     if (use_viz) {
         if (cfg.viz_mode == VIZ_MODE_VU) {
             if (surplus > 0) y += surplus / 2;
-        } else {
+        } else if (surplus > 0) {
+            // Never add negative surplus: that would drag the panel below the
+            // 12px floor; the overflow guards drop elements instead.
             viz_h += surplus;
         }
     } else if (surplus > 0) {

--- a/src/layout.c
+++ b/src/layout.c
@@ -4,9 +4,6 @@
 
 Layout layout;
 
-// Sunken panel border + padding around the visualizer's drawing region.
-#define VIZ_PANEL_PAD 4
-
 static int clamp_i(int value, int lo, int hi) {
     if (value < lo) return lo;
     if (value > hi) return hi;
@@ -22,6 +19,17 @@ static Rect zero_rect(void) {
     return r;
 }
 
+// All pixel constants are defined at 1x (320x240) and multiplied by the
+// resolution scale so the composition is identical at 640x480.
+static int ui_scale(void) {
+    return (cfg.ui_scale > 0) ? cfg.ui_scale : 1;
+}
+
+// Sunken panel border + padding around the visualizer's drawing region.
+static int viz_panel_pad(void) {
+    return 4 * ui_scale();
+}
+
 static void reset_viz_geometry(void) {
     layout.viz_max_h = 0;
     layout.viz_spacing = 0;
@@ -32,6 +40,7 @@ static void reset_viz_geometry(void) {
 
 // Bar/meter geometry is derived from the panel interior, not the panel rect.
 static void compute_viz_geometry(void) {
+    const int s = ui_scale();
     if (layout.viz_inner.w <= 0 || layout.viz_inner.h <= 0) {
         reset_viz_geometry();
         return;
@@ -49,11 +58,11 @@ static void compute_viz_geometry(void) {
 
     int bar_width = spacing - 1;
     if (bar_width < 1) bar_width = 1;
-    if (bar_width > 4) bar_width = 4;
+    if (bar_width > 4 * s) bar_width = 4 * s;
     layout.viz_bar_width = bar_width;
 
-    layout.viz_meter_w = layout.viz_inner.w - 16;
-    if (layout.viz_meter_w < 8) layout.viz_meter_w = layout.viz_inner.w;
+    layout.viz_meter_w = layout.viz_inner.w - 16 * s;
+    if (layout.viz_meter_w < 8 * s) layout.viz_meter_w = layout.viz_inner.w;
     if (layout.viz_meter_w < 1) layout.viz_meter_w = 1;
 }
 
@@ -61,7 +70,7 @@ static void compute_viz_inner(void) {
     layout.viz_inner = zero_rect();
     if (layout.viz.w <= 0 || layout.viz.h <= 0) return;
 
-    int pad = VIZ_PANEL_PAD;
+    int pad = viz_panel_pad();
     if (layout.viz.w <= pad * 2 + 2 || layout.viz.h <= pad * 2 + 2) pad = 1;
     layout.viz_inner.x = layout.viz.x + pad;
     layout.viz_inner.y = layout.viz.y + pad;
@@ -71,19 +80,20 @@ static void compute_viz_inner(void) {
 }
 
 static void place_art(void) {
-    const int gap_after_art = 8;   // room for the frame, drop shadow, and breathing space
-    const int frame_inset = 2;     // bevel frame drawn just outside the art rect
+    const int s = ui_scale();
+    const int gap_after_art = 8 * s;   // room for the frame, drop shadow, and breathing space
+    const int frame_inset = 2 * s;     // bevel frame drawn just outside the art rect
     if (!cfg.show_art) return;
 
     int art_side = min_i(layout.area_w, layout.area_h) * 40 / 100;
-    art_side = clamp_i(art_side, 32, 120);
+    art_side = clamp_i(art_side, 32 * s, 120 * s);
 
     if (layout.is_wide) {
-        int max_side = layout.area_w - frame_inset - gap_after_art - 48;
+        int max_side = layout.area_w - frame_inset - gap_after_art - 48 * s;
         if (max_side < 0) max_side = 0;
         if (art_side > max_side) art_side = max_side;
-        // Reserve the frame inset above plus frame + drop shadow (4px) below.
-        if (art_side > layout.area_h - frame_inset - 4) art_side = layout.area_h - frame_inset - 4;
+        // Reserve the frame inset above plus frame + drop shadow below.
+        if (art_side > layout.area_h - frame_inset - 4 * s) art_side = layout.area_h - frame_inset - 4 * s;
         if (art_side > 0) {
             // Top-aligned so the art frame's top edge lines up with the
             // visualizer panel's top edge instead of floating mid-column.
@@ -93,11 +103,11 @@ static void place_art(void) {
             layout.art.h = art_side;
         }
     } else {
-        int max_side = layout.area_h - frame_inset - gap_after_art - 56;
+        int max_side = layout.area_h - frame_inset - gap_after_art - 56 * s;
         if (max_side < 0) max_side = 0;
         if (art_side > max_side) art_side = max_side;
-        // Frame on both sides plus the drop shadow's 2px to the right.
-        if (art_side > layout.area_w - frame_inset * 2 - 2) art_side = layout.area_w - frame_inset * 2 - 2;
+        // Frame on both sides plus the drop shadow to the right.
+        if (art_side > layout.area_w - frame_inset * 2 - 2 * s) art_side = layout.area_w - frame_inset * 2 - 2 * s;
         if (art_side > 0) {
             layout.art.x = layout.area_x + (layout.area_w - art_side) / 2;
             layout.art.y = layout.area_y + frame_inset;
@@ -122,6 +132,7 @@ static void place_art(void) {
 }
 
 void layout_compute(void) {
+    const int s = ui_scale();
     const int top_pct = clamp_i(cfg.ui_top, 0, 100);
     const int left_pct = clamp_i(cfg.ui_left, 0, 100);
     int bottom_pct = clamp_i(cfg.ui_bottom, 0, 100);
@@ -130,15 +141,15 @@ void layout_compute(void) {
     if (bottom_pct <= top_pct) bottom_pct = clamp_i(top_pct + 1, 1, 100);
     if (right_pct <= left_pct) right_pct = clamp_i(left_pct + 1, 1, 100);
 
-    int x0 = FB_WIDTH * left_pct / 100;
-    int x1 = FB_WIDTH * right_pct / 100;
-    int y0 = FB_HEIGHT * top_pct / 100;
-    int y1 = FB_HEIGHT * bottom_pct / 100;
+    int x0 = fb_width * left_pct / 100;
+    int x1 = fb_width * right_pct / 100;
+    int y0 = fb_height * top_pct / 100;
+    int y1 = fb_height * bottom_pct / 100;
 
     if (x1 <= x0) x1 = x0 + 1;
     if (y1 <= y0) y1 = y0 + 1;
-    if (x1 > FB_WIDTH) x1 = FB_WIDTH;
-    if (y1 > FB_HEIGHT) y1 = FB_HEIGHT;
+    if (x1 > fb_width) x1 = fb_width;
+    if (y1 > fb_height) y1 = fb_height;
 
     layout.area_x = x0;
     layout.area_y = y0;
@@ -178,12 +189,12 @@ void layout_compute(void) {
     if (layout.content_w < 1) layout.content_w = 1;
     if (layout.content_h < 1) layout.content_h = 1;
 
-    const int transport_h = 12;
-    const int bar_h = 8;
-    const int time_h = 8;
-    const int cluster_gap = 2;
-    const int viz_min_h = 20;                       // 12px of drawing inside the panel
-    const int vu_compact_h = 16 + 2 * VIZ_PANEL_PAD;
+    const int transport_h = 12 * s;
+    const int bar_h = 8 * s;
+    const int time_h = 8 * s;
+    const int cluster_gap = 2 * s;
+    const int viz_min_h = 20 * s;                        // 12px of drawing inside the panel
+    const int vu_compact_h = 16 * s + 2 * viz_panel_pad();
 
     const int use_viz = cfg.show_viz ? 1 : 0;
     const int use_text = cfg.show_txt ? 1 : 0;
@@ -201,7 +212,7 @@ void layout_compute(void) {
     // Fit pass. On short screens the transport row vanishes first, then the
     // large title falls back to 1x, then the visualizer panel gives up height.
     for (;;) {
-        int text_h = use_text ? 8 * text_scale : 0;
+        int text_h = use_text ? 8 * text_scale * s : 0;
         int members = use_text + use_bar + use_time;
         cluster_h = text_h + (use_bar ? bar_h : 0) + (use_time ? time_h : 0);
         if (members > 1) cluster_h += (members - 1) * cluster_gap;
@@ -215,7 +226,7 @@ void layout_compute(void) {
     if (use_viz && fixed_h > layout.content_h) {
         // VU never shrinks below two meter rows (no mono fallback); the
         // overflow guards drop other elements instead.
-        int viz_floor = (cfg.viz_mode == VIZ_MODE_VU) ? vu_compact_h : 12;
+        int viz_floor = (cfg.viz_mode == VIZ_MODE_VU) ? vu_compact_h : 12 * s;
         viz_h -= (fixed_h - layout.content_h);
         if (viz_h < viz_floor) viz_h = viz_floor;
         fixed_h = viz_h + cluster_h;
@@ -227,7 +238,7 @@ void layout_compute(void) {
     int group_gap = 0;
     if (gap_count > 0 && layout.content_h > fixed_h) {
         group_gap = (layout.content_h - fixed_h) / gap_count;
-        if (group_gap > 8) group_gap = 8;
+        if (group_gap > 8 * s) group_gap = 8 * s;
     }
 
     int used_h = fixed_h + (group_gap * gap_count);
@@ -238,7 +249,7 @@ void layout_compute(void) {
             if (surplus > 0) y += surplus / 2;
         } else if (surplus > 0) {
             // Never add negative surplus: that would drag the panel below the
-            // 12px floor; the overflow guards drop elements instead.
+            // floor; the overflow guards drop elements instead.
             viz_h += surplus;
         }
     } else if (surplus > 0) {
@@ -259,7 +270,7 @@ void layout_compute(void) {
         layout.text.x = layout.content_x;
         layout.text.y = y;
         layout.text.w = layout.content_w;
-        layout.text.h = 8 * text_scale;
+        layout.text.h = 8 * text_scale * s;
         layout.text_scale = text_scale;
         y += layout.text.h;
         if (use_bar || use_time) y += cluster_gap;
@@ -304,12 +315,12 @@ void layout_compute(void) {
         // Transport anchors: prev / play-pause / next trio around the center,
         // shuffle to the right of the trio.
         int center = layout.icons.x + layout.icons.w / 2;
-        layout.icon_pause_x = center - 5;
-        layout.icon_seek_x = layout.icon_pause_x - 24;
-        layout.icon_shuffle_x = layout.icon_pause_x + 48;
+        layout.icon_pause_x = center - 5 * s;
+        layout.icon_seek_x = layout.icon_pause_x - 24 * s;
+        layout.icon_shuffle_x = layout.icon_pause_x + 48 * s;
         if (layout.icon_seek_x < layout.icons.x) layout.icon_seek_x = layout.icons.x;
-        if (layout.icon_shuffle_x + 10 > layout.icons.x + layout.icons.w)
-            layout.icon_shuffle_x = layout.icons.x + layout.icons.w - 10;
+        if (layout.icon_shuffle_x + 10 * s > layout.icons.x + layout.icons.w)
+            layout.icon_shuffle_x = layout.icons.x + layout.icons.w - 10 * s;
     } else {
         layout.icon_shuffle_x = layout.content_x;
         layout.icon_seek_x = layout.content_x;

--- a/src/layout.h
+++ b/src/layout.h
@@ -13,7 +13,6 @@ typedef struct {
 
     // Album art region. Zero-sized when art does not reserve space.
     Rect art;
-    bool art_reserves_space;
 
     // Remaining content area after art placement.
     int content_x, content_y, content_w, content_h;

--- a/src/layout.h
+++ b/src/layout.h
@@ -18,8 +18,15 @@ typedef struct {
     // Remaining content area after art placement.
     int content_x, content_y, content_w, content_h;
 
-    // Element bounds.
+    // Element bounds. icons is the transport row (bottom of the stack); it is
+    // zero-sized when the user hides it or when the content area is too short.
     Rect icons, text, viz, bar, time;
+
+    // Region inside the sunken visualizer panel where modes actually draw.
+    Rect viz_inner;
+
+    // Title glyph scale (2 when there is room for a large title, else 1).
+    int text_scale;
 
     // Icon anchors.
     int icon_shuffle_x;

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,6 +1,5 @@
 // Screen composition for the Hi-Fi Deck look: background, framed art, sunken
-// visualizer panel, marquee title, progress bar, and transport icons. Handles
-// both the responsive layout and the manual media_*_y offset fallback.
+// visualizer panel, marquee title, progress bar, and transport icons.
 #include "ui.h"
 #include "video.h"
 #include "config.h"
@@ -105,23 +104,6 @@ static void icon_shuffle(int x, int y, uint16_t c) {
     }
 }
 
-static void icon_seek(int x, int y, int dir, uint16_t c) {
-    // Double chevron pointing in the seek direction.
-    for (int r = 0; r < ICON_SIZE; r++) {
-        int d = (r < ICON_SIZE / 2) ? r : ICON_SIZE - 1 - r;
-        int w = 1 + d;
-        for (int i = 0; i < w; i++) {
-            if (dir > 0) {
-                draw_pixel(x + i, y + r, c);
-                draw_pixel(x + 5 + i, y + r, c);
-            } else {
-                draw_pixel(x + ICON_SIZE - 1 - i, y + r, c);
-                draw_pixel(x + 4 - i, y + r, c);
-            }
-        }
-    }
-}
-
 // ---- Shared building blocks ------------------------------------------------
 
 static void ui_blit_art(int x, int y, int w, int h) {
@@ -182,8 +164,6 @@ static void ui_draw_debug_overlay(void) {
     draw_rect_outline(layout.time.x, layout.time.y, layout.time.w, layout.time.h, 0x001F);
 }
 
-// ---- Responsive layout -----------------------------------------------------
-
 static void ui_draw_transport(const UiFrame *f, const UiPalette *pal) {
     Rect r = layout.icons;
     int y = r.y + (r.h - ICON_SIZE) / 2;
@@ -210,7 +190,7 @@ static void ui_draw_transport(const UiFrame *f, const UiPalette *pal) {
     }
 }
 
-static void ui_draw_responsive(UiFrame *f, const UiPalette *pal) {
+static void ui_draw_screen(UiFrame *f, const UiPalette *pal) {
     if (cfg.show_art && layout.art.w > 0 && layout.art.h > 0)
         ui_draw_art_framed(layout.art.x, layout.art.y, layout.art.w, layout.art.h, pal);
 
@@ -260,53 +240,8 @@ static void ui_draw_responsive(UiFrame *f, const UiPalette *pal) {
     if (cfg.debug_layout) ui_draw_debug_overlay();
 }
 
-// ---- Manual-offset fallback (media_*_y positions) --------------------------
-
-static void ui_draw_legacy(UiFrame *f, const UiPalette *pal) {
-    if (cfg.show_art && art_buffer)
-        ui_draw_art_framed(120, cfg.art_y, 80, 80, pal);
-
-    if (cfg.show_txt) {
-        draw_text(*f->scroll_x, cfg.txt_y, display_str, pal->fg);
-        (*f->scroll_x)--;
-        if (*f->scroll_x < -((int)strlen(display_str) * GLYPH_WIDTH)) *f->scroll_x = FB_WIDTH;
-    }
-
-    if (cfg.show_viz) viz_draw();
-
-    if (cfg.show_bar && f->total_frames > 0) {
-        draw_rect_outline(60, cfg.bar_y, 200, 8, pal->fg_dim);
-        draw_rect_fill(61, cfg.bar_y + 1, 198, 6, pal->panel);
-        int fill = progress_width(f, 198);
-        if (fill > 0) draw_rect_fill(61, cfg.bar_y + 1, fill, 6, pal->fg_dim);
-        int handle_x = 61 + ((fill > 2) ? fill - 2 : 0);
-        draw_rect_fill(handle_x, cfg.bar_y + 1, 2, 6, pal->handle);
-    }
-
-    if (cfg.show_tim) {
-        char elapsed[16];
-        format_time(elapsed, sizeof(elapsed), f->cur_frame, f->source_rate);
-        if (f->total_frames > 0) {
-            char total[16];
-            char line[40];
-            format_time(total, sizeof(total), f->total_frames, f->source_rate);
-            snprintf(line, sizeof(line), "%s / %s", elapsed, total);
-            draw_text((FB_WIDTH - (int)strlen(line) * GLYPH_WIDTH) / 2, cfg.tim_y, line, pal->fg);
-        } else {
-            draw_text(140, cfg.tim_y, elapsed, pal->fg);
-        }
-    }
-
-    if (cfg.show_ico) {
-        if (f->shuffle) icon_shuffle(20, cfg.ico_y, pal->fg);
-        if (f->paused) icon_pause(280, cfg.ico_y, pal->fg);
-        if (f->seek_dir != 0) icon_seek(60, cfg.ico_y, f->seek_dir, pal->fg);
-    }
-}
-
 void ui_draw(UiFrame *frame) {
     UiPalette pal = ui_palette();
     video_fill_vgradient(pal.bg_top, pal.bg_bottom);
-    if (cfg.responsive) ui_draw_responsive(frame, &pal);
-    else ui_draw_legacy(frame, &pal);
+    ui_draw_screen(frame, &pal);
 }

--- a/src/ui.c
+++ b/src/ui.c
@@ -153,15 +153,22 @@ static void ui_update_marquee(int *scroll_x, int text_w, int region_x, int regio
     if (*scroll_x == min_x) marquee_hold = MARQUEE_HOLD_FRAMES;
 }
 
+// Outline 1px outside the rect so the overlay never overwrites the pixels
+// it is annotating (an on-rect outline eats the top row of 8x8 glyphs).
+static void debug_box(int x, int y, int w, int h, uint16_t color) {
+    if (w <= 0 || h <= 0) return;
+    draw_rect_outline(x - 1, y - 1, w + 2, h + 2, color);
+}
+
 static void ui_draw_debug_overlay(void) {
-    draw_rect_outline(layout.area_x, layout.area_y, layout.area_w, layout.area_h, 0x07FF);
-    draw_rect_outline(layout.content_x, layout.content_y, layout.content_w, layout.content_h, 0x07E0);
-    draw_rect_outline(layout.art.x, layout.art.y, layout.art.w, layout.art.h, 0xFFE0);
-    draw_rect_outline(layout.icons.x, layout.icons.y, layout.icons.w, layout.icons.h, 0xFD20);
-    draw_rect_outline(layout.text.x, layout.text.y, layout.text.w, layout.text.h, 0xF81F);
-    draw_rect_outline(layout.viz.x, layout.viz.y, layout.viz.w, layout.viz.h, 0xF800);
-    draw_rect_outline(layout.bar.x, layout.bar.y, layout.bar.w, layout.bar.h, 0xFFFF);
-    draw_rect_outline(layout.time.x, layout.time.y, layout.time.w, layout.time.h, 0x001F);
+    debug_box(layout.area_x, layout.area_y, layout.area_w, layout.area_h, 0x07FF);
+    debug_box(layout.content_x, layout.content_y, layout.content_w, layout.content_h, 0x07E0);
+    debug_box(layout.art.x, layout.art.y, layout.art.w, layout.art.h, 0xFFE0);
+    debug_box(layout.icons.x, layout.icons.y, layout.icons.w, layout.icons.h, 0xFD20);
+    debug_box(layout.text.x, layout.text.y, layout.text.w, layout.text.h, 0xF81F);
+    debug_box(layout.viz.x, layout.viz.y, layout.viz.w, layout.viz.h, 0xF800);
+    debug_box(layout.bar.x, layout.bar.y, layout.bar.w, layout.bar.h, 0xFFFF);
+    debug_box(layout.time.x, layout.time.y, layout.time.w, layout.time.h, 0x001F);
 }
 
 static void ui_draw_transport(const UiFrame *f, const UiPalette *pal) {

--- a/src/ui.c
+++ b/src/ui.c
@@ -9,10 +9,17 @@
 #include <stdio.h>
 #include <string.h>
 
-#define MARQUEE_HOLD_FRAMES 90
+#define MARQUEE_HOLD_SEC 1.5f
+#define MARQUEE_SPEED_PXS 60.0f
 #define ICON_SIZE 10
 
-static int marquee_hold = MARQUEE_HOLD_FRAMES;
+static float ui_dt = 1.0f / 60.0f;
+static float marquee_hold = MARQUEE_HOLD_SEC;
+static float marquee_frac = 0.0f;
+
+void ui_set_frame_dt(float dt) {
+    ui_dt = dt;
+}
 
 // Every chrome color is derived from the user's bg/fg pair so the core
 // options keep controlling the theme.
@@ -41,7 +48,8 @@ static UiPalette ui_palette(void) {
 }
 
 void ui_reset_marquee(void) {
-    marquee_hold = MARQUEE_HOLD_FRAMES;
+    marquee_hold = MARQUEE_HOLD_SEC;
+    marquee_frac = 0.0f;
 }
 
 static void format_time(char *out, size_t out_sz, uint64_t frames, uint32_t rate) {
@@ -127,7 +135,8 @@ static void ui_draw_art_framed(int x, int y, int w, int h, const UiPalette *pal)
 }
 
 // Marquee: hold at the start, crawl left until the tail is visible, hold,
-// snap back. Static text stays pinned to the region's left edge.
+// snap back. Static text stays pinned to the region's left edge. Speed and
+// holds are in real time so playback rate stays correct on non-60Hz hosts.
 static void ui_update_marquee(int *scroll_x, int text_w, int region_x, int region_w) {
     if (text_w <= region_w) {
         *scroll_x = region_x;
@@ -137,20 +146,30 @@ static void ui_update_marquee(int *scroll_x, int text_w, int region_x, int regio
     int min_x = region_x + region_w - text_w;
     if (*scroll_x > region_x || *scroll_x < min_x) {
         *scroll_x = region_x;
-        marquee_hold = MARQUEE_HOLD_FRAMES;
+        marquee_hold = MARQUEE_HOLD_SEC;
+        marquee_frac = 0.0f;
         return;
     }
-    if (marquee_hold > 0) {
-        marquee_hold--;
+    if (marquee_hold > 0.0f) {
+        marquee_hold -= ui_dt;
         return;
     }
     if (*scroll_x == min_x) {
         *scroll_x = region_x;
-        marquee_hold = MARQUEE_HOLD_FRAMES;
+        marquee_hold = MARQUEE_HOLD_SEC;
+        marquee_frac = 0.0f;
         return;
     }
-    (*scroll_x)--;
-    if (*scroll_x == min_x) marquee_hold = MARQUEE_HOLD_FRAMES;
+    marquee_frac += MARQUEE_SPEED_PXS * ui_dt;
+    int move = (int)marquee_frac;
+    if (move > 0) {
+        marquee_frac -= (float)move;
+        *scroll_x -= move;
+        if (*scroll_x <= min_x) {
+            *scroll_x = min_x;
+            marquee_hold = MARQUEE_HOLD_SEC;
+        }
+    }
 }
 
 // Outline 1px outside the rect so the overlay never overwrites the pixels

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,0 +1,309 @@
+// Screen composition for the Hi-Fi Deck look: background, framed art, sunken
+// visualizer panel, marquee title, progress bar, and transport icons. Handles
+// both the responsive layout and the manual media_*_y offset fallback.
+#include "ui.h"
+#include "video.h"
+#include "config.h"
+#include "layout.h"
+#include "metadata.h"
+#include "visualizer.h"
+#include <stdio.h>
+#include <string.h>
+
+#define MARQUEE_HOLD_FRAMES 90
+#define ICON_SIZE 10
+
+static int marquee_hold = MARQUEE_HOLD_FRAMES;
+
+// Every chrome color is derived from the user's bg/fg pair so the core
+// options keep controlling the theme.
+typedef struct {
+    uint16_t fg, fg_dim, fg_faint;
+    uint16_t bg_top, bg_bottom;
+    uint16_t panel, frame_face, bevel_light, bevel_dark, shadow, handle;
+} UiPalette;
+
+static UiPalette ui_palette(void) {
+    UiPalette p;
+    uint16_t bg = cfg.bg_rgb;
+    uint16_t fg = cfg.fg_rgb;
+    p.fg = fg;
+    p.fg_dim = mix565(fg, bg, 110);
+    p.fg_faint = mix565(fg, bg, 185);
+    p.bg_top = mix565(bg, 0xFFFF, 14);
+    p.bg_bottom = mix565(bg, 0x0000, 96);
+    p.panel = mix565(bg, 0x0000, 150);
+    p.frame_face = mix565(bg, fg, 40);
+    p.bevel_light = mix565(bg, 0xFFFF, 90);
+    p.bevel_dark = mix565(bg, 0x0000, 190);
+    p.shadow = mix565(bg, 0x0000, 210);
+    p.handle = mix565(fg, 0xFFFF, 110);
+    return p;
+}
+
+void ui_reset_marquee(void) {
+    marquee_hold = MARQUEE_HOLD_FRAMES;
+}
+
+static void format_time(char *out, size_t out_sz, uint64_t frames, uint32_t rate) {
+    int sec = rate ? (int)(frames / rate) : 0;
+    snprintf(out, out_sz, "%02d:%02d", sec / 60, sec % 60);
+}
+
+static int progress_width(const UiFrame *f, int width) {
+    if (width <= 0 || f->total_frames == 0 || f->cur_frame == 0) return 0;
+    if (f->cur_frame >= f->total_frames) return width;
+    return (int)(((double)f->cur_frame / (double)f->total_frames) * (double)width);
+}
+
+// ---- Pixel transport icons (10x10, drawn procedurally) ---------------------
+
+static void icon_play(int x, int y, uint16_t c) {
+    for (int r = 0; r < ICON_SIZE; r++) {
+        int d = (r < ICON_SIZE / 2) ? r : ICON_SIZE - 1 - r;
+        int w = 2 + d * 2;
+        for (int i = 0; i < w; i++) draw_pixel(x + i, y + r, c);
+    }
+}
+
+static void icon_pause(int x, int y, uint16_t c) {
+    draw_rect_fill(x, y, 3, ICON_SIZE, c);
+    draw_rect_fill(x + 7, y, 3, ICON_SIZE, c);
+}
+
+static void icon_prev(int x, int y, uint16_t c) {
+    draw_rect_fill(x, y, 2, ICON_SIZE, c);
+    for (int r = 0; r < ICON_SIZE; r++) {
+        int d = (r < ICON_SIZE / 2) ? r : ICON_SIZE - 1 - r;
+        int w = 2 + d * 2;
+        if (w > 8) w = 8;
+        for (int i = 0; i < w; i++) draw_pixel(x + ICON_SIZE - 1 - i, y + r, c);
+    }
+}
+
+static void icon_next(int x, int y, uint16_t c) {
+    for (int r = 0; r < ICON_SIZE; r++) {
+        int d = (r < ICON_SIZE / 2) ? r : ICON_SIZE - 1 - r;
+        int w = 2 + d * 2;
+        if (w > 8) w = 8;
+        for (int i = 0; i < w; i++) draw_pixel(x + i, y + r, c);
+    }
+    draw_rect_fill(x + 8, y, 2, ICON_SIZE, c);
+}
+
+static void icon_shuffle(int x, int y, uint16_t c) {
+    for (int i = 0; i < 9; i++) {
+        draw_pixel(x + i, y + i, c);
+        draw_pixel(x + i, y + 8 - i, c);
+    }
+    draw_pixel(x + 7, y, c);
+    draw_pixel(x + 8, y + 1, c);
+    draw_pixel(x + 7, y + 8, c);
+    draw_pixel(x + 8, y + 7, c);
+}
+
+static void icon_seek(int x, int y, int dir, uint16_t c) {
+    // Double chevron pointing in the seek direction.
+    for (int r = 0; r < ICON_SIZE; r++) {
+        int d = (r < ICON_SIZE / 2) ? r : ICON_SIZE - 1 - r;
+        int w = 1 + d;
+        for (int i = 0; i < w; i++) {
+            if (dir > 0) {
+                draw_pixel(x + i, y + r, c);
+                draw_pixel(x + 5 + i, y + r, c);
+            } else {
+                draw_pixel(x + ICON_SIZE - 1 - i, y + r, c);
+                draw_pixel(x + 4 - i, y + r, c);
+            }
+        }
+    }
+}
+
+// ---- Shared building blocks ------------------------------------------------
+
+static void ui_blit_art(int x, int y, int w, int h) {
+    if (!art_buffer || w <= 0 || h <= 0) return;
+    for (int j = 0; j < h; j++) {
+        int src_y = j * art_h_src / h;
+        for (int i = 0; i < w; i++) {
+            int src_x = i * art_w_src / w;
+            draw_pixel(x + i, y + j, art_buffer[src_y * art_w_src + src_x]);
+        }
+    }
+}
+
+static void ui_draw_art_framed(int x, int y, int w, int h, const UiPalette *pal) {
+    if (!art_buffer || w <= 0 || h <= 0) return;
+    draw_rect_fill(x, y + h + 2, w + 4, 2, pal->shadow);
+    draw_rect_fill(x + w + 2, y, 2, h + 2, pal->shadow);
+    draw_rect_outline(x - 1, y - 1, w + 2, h + 2, pal->frame_face);
+    draw_rect_bevel(x - 2, y - 2, w + 4, h + 4, pal->bevel_light, pal->bevel_dark);
+    ui_blit_art(x, y, w, h);
+}
+
+// Marquee: hold at the start, crawl left until the tail is visible, hold,
+// snap back. Static text stays pinned to the region's left edge.
+static void ui_update_marquee(int *scroll_x, int text_w, int region_x, int region_w) {
+    if (text_w <= region_w) {
+        *scroll_x = region_x;
+        return;
+    }
+
+    int min_x = region_x + region_w - text_w;
+    if (*scroll_x > region_x || *scroll_x < min_x) {
+        *scroll_x = region_x;
+        marquee_hold = MARQUEE_HOLD_FRAMES;
+        return;
+    }
+    if (marquee_hold > 0) {
+        marquee_hold--;
+        return;
+    }
+    if (*scroll_x == min_x) {
+        *scroll_x = region_x;
+        marquee_hold = MARQUEE_HOLD_FRAMES;
+        return;
+    }
+    (*scroll_x)--;
+    if (*scroll_x == min_x) marquee_hold = MARQUEE_HOLD_FRAMES;
+}
+
+static void ui_draw_debug_overlay(void) {
+    draw_rect_outline(layout.area_x, layout.area_y, layout.area_w, layout.area_h, 0x07FF);
+    draw_rect_outline(layout.content_x, layout.content_y, layout.content_w, layout.content_h, 0x07E0);
+    draw_rect_outline(layout.art.x, layout.art.y, layout.art.w, layout.art.h, 0xFFE0);
+    draw_rect_outline(layout.icons.x, layout.icons.y, layout.icons.w, layout.icons.h, 0xFD20);
+    draw_rect_outline(layout.text.x, layout.text.y, layout.text.w, layout.text.h, 0xF81F);
+    draw_rect_outline(layout.viz.x, layout.viz.y, layout.viz.w, layout.viz.h, 0xF800);
+    draw_rect_outline(layout.bar.x, layout.bar.y, layout.bar.w, layout.bar.h, 0xFFFF);
+    draw_rect_outline(layout.time.x, layout.time.y, layout.time.w, layout.time.h, 0x001F);
+}
+
+// ---- Responsive layout -----------------------------------------------------
+
+static void ui_draw_transport(const UiFrame *f, const UiPalette *pal) {
+    Rect r = layout.icons;
+    int y = r.y + (r.h - ICON_SIZE) / 2;
+    int play_x = layout.icon_pause_x;
+    bool trio_fits = r.w >= 58;
+
+    if (trio_fits)
+        icon_prev(layout.icon_seek_x, y, (f->seek_dir < 0) ? pal->fg : pal->fg_faint);
+    if (f->paused) icon_pause(play_x, y, pal->fg);
+    else icon_play(play_x, y, pal->fg);
+    if (trio_fits)
+        icon_next(play_x + 24, y, (f->seek_dir > 0) ? pal->fg : pal->fg_faint);
+
+    if (trio_fits && layout.icon_shuffle_x >= play_x + 24 + ICON_SIZE + 4)
+        icon_shuffle(layout.icon_shuffle_x, y, f->shuffle ? pal->fg : pal->fg_faint);
+
+    if (f->track_count > 1) {
+        char counter[24];
+        snprintf(counter, sizeof(counter), "%d/%d", f->track_index + 1, f->track_count);
+        int cw = (int)strlen(counter) * GLYPH_WIDTH;
+        int cx = r.x + r.w - cw;
+        if (cx >= layout.icon_shuffle_x + ICON_SIZE + 6)
+            draw_text(cx, r.y + (r.h - 8) / 2, counter, pal->fg_faint);
+    }
+}
+
+static void ui_draw_responsive(UiFrame *f, const UiPalette *pal) {
+    if (cfg.show_art && layout.art.w > 0 && layout.art.h > 0)
+        ui_draw_art_framed(layout.art.x, layout.art.y, layout.art.w, layout.art.h, pal);
+
+    if (cfg.show_viz && layout.viz.w > 0 && layout.viz.h > 0) {
+        draw_rect_fill(layout.viz.x, layout.viz.y, layout.viz.w, layout.viz.h, pal->panel);
+        draw_rect_bevel(layout.viz.x, layout.viz.y, layout.viz.w, layout.viz.h,
+                        pal->bevel_dark, pal->bevel_light);
+        viz_draw();
+    }
+
+    if (cfg.show_txt && layout.text.w > 0) {
+        int scale = (layout.text_scale > 0) ? layout.text_scale : 1;
+        int text_w = (int)strlen(display_str) * GLYPH_WIDTH * scale;
+        ui_update_marquee(f->scroll_x, text_w, layout.text.x, layout.text.w);
+        draw_text_scaled_clipped(*f->scroll_x, layout.text.y, display_str, pal->fg,
+                                 scale, layout.text.x, layout.text.w);
+    }
+
+    if (cfg.show_bar && f->total_frames > 0 && layout.bar.w > 2 && layout.bar.h > 2) {
+        draw_rect_outline(layout.bar.x, layout.bar.y, layout.bar.w, layout.bar.h, pal->fg_dim);
+        draw_rect_fill(layout.bar.x + 1, layout.bar.y + 1,
+                       layout.bar.w - 2, layout.bar.h - 2, pal->panel);
+        int fill = progress_width(f, layout.bar.w - 2);
+        if (fill > 0)
+            draw_rect_fill(layout.bar.x + 1, layout.bar.y + 1, fill, layout.bar.h - 2, pal->fg_dim);
+        int handle_x = layout.bar.x + 1 + ((fill > 2) ? fill - 2 : 0);
+        draw_rect_fill(handle_x, layout.bar.y + 1, 2, layout.bar.h - 2, pal->handle);
+    }
+
+    if (cfg.show_tim && layout.time.w > 0) {
+        char elapsed[16];
+        format_time(elapsed, sizeof(elapsed), f->cur_frame, f->source_rate);
+        int x0 = (layout.bar.w > 0) ? layout.bar.x : layout.time.x;
+        int x1 = (layout.bar.w > 0) ? layout.bar.x + layout.bar.w
+                                    : layout.time.x + layout.time.w;
+        draw_text(x0, layout.time.y, elapsed, pal->fg_dim);
+        if (f->total_frames > 0) {
+            char total[16];
+            format_time(total, sizeof(total), f->total_frames, f->source_rate);
+            draw_text(x1 - (int)strlen(total) * GLYPH_WIDTH, layout.time.y, total, pal->fg_dim);
+        }
+    }
+
+    if (cfg.show_ico && layout.icons.w > 0 && layout.icons.h > 0)
+        ui_draw_transport(f, pal);
+
+    if (cfg.debug_layout) ui_draw_debug_overlay();
+}
+
+// ---- Manual-offset fallback (media_*_y positions) --------------------------
+
+static void ui_draw_legacy(UiFrame *f, const UiPalette *pal) {
+    if (cfg.show_art && art_buffer)
+        ui_draw_art_framed(120, cfg.art_y, 80, 80, pal);
+
+    if (cfg.show_txt) {
+        draw_text(*f->scroll_x, cfg.txt_y, display_str, pal->fg);
+        (*f->scroll_x)--;
+        if (*f->scroll_x < -((int)strlen(display_str) * GLYPH_WIDTH)) *f->scroll_x = FB_WIDTH;
+    }
+
+    if (cfg.show_viz) viz_draw();
+
+    if (cfg.show_bar && f->total_frames > 0) {
+        draw_rect_outline(60, cfg.bar_y, 200, 8, pal->fg_dim);
+        draw_rect_fill(61, cfg.bar_y + 1, 198, 6, pal->panel);
+        int fill = progress_width(f, 198);
+        if (fill > 0) draw_rect_fill(61, cfg.bar_y + 1, fill, 6, pal->fg_dim);
+        int handle_x = 61 + ((fill > 2) ? fill - 2 : 0);
+        draw_rect_fill(handle_x, cfg.bar_y + 1, 2, 6, pal->handle);
+    }
+
+    if (cfg.show_tim) {
+        char elapsed[16];
+        format_time(elapsed, sizeof(elapsed), f->cur_frame, f->source_rate);
+        if (f->total_frames > 0) {
+            char total[16];
+            char line[40];
+            format_time(total, sizeof(total), f->total_frames, f->source_rate);
+            snprintf(line, sizeof(line), "%s / %s", elapsed, total);
+            draw_text((FB_WIDTH - (int)strlen(line) * GLYPH_WIDTH) / 2, cfg.tim_y, line, pal->fg);
+        } else {
+            draw_text(140, cfg.tim_y, elapsed, pal->fg);
+        }
+    }
+
+    if (cfg.show_ico) {
+        if (f->shuffle) icon_shuffle(20, cfg.ico_y, pal->fg);
+        if (f->paused) icon_pause(280, cfg.ico_y, pal->fg);
+        if (f->seek_dir != 0) icon_seek(60, cfg.ico_y, f->seek_dir, pal->fg);
+    }
+}
+
+void ui_draw(UiFrame *frame) {
+    UiPalette pal = ui_palette();
+    video_fill_vgradient(pal.bg_top, pal.bg_bottom);
+    if (cfg.responsive) ui_draw_responsive(frame, &pal);
+    else ui_draw_legacy(frame, &pal);
+}

--- a/src/ui.c
+++ b/src/ui.c
@@ -21,6 +21,12 @@ void ui_set_frame_dt(float dt) {
     ui_dt = dt;
 }
 
+// Resolution scale: chrome is authored at 1x (320x240) and multiplied so the
+// composition is identical at 640x480, just crisper where it counts.
+static int ui_s(void) {
+    return (cfg.ui_scale > 0) ? cfg.ui_scale : 1;
+}
+
 // Every chrome color is derived from the user's bg/fg pair so the core
 // options keep controlling the theme.
 typedef struct {
@@ -63,52 +69,60 @@ static int progress_width(const UiFrame *f, int width) {
     return (int)(((double)f->cur_frame / (double)f->total_frames) * (double)width);
 }
 
-// ---- Pixel transport icons (10x10, drawn procedurally) ---------------------
+// ---- Pixel transport icons (10x10 unit grid, each unit an s x s block) -----
+
+static void icon_px(int x, int y, int ux, int uy, uint16_t c) {
+    int s = ui_s();
+    draw_rect_fill(x + ux * s, y + uy * s, s, s, c);
+}
 
 static void icon_play(int x, int y, uint16_t c) {
     for (int r = 0; r < ICON_SIZE; r++) {
         int d = (r < ICON_SIZE / 2) ? r : ICON_SIZE - 1 - r;
         int w = 2 + d * 2;
-        for (int i = 0; i < w; i++) draw_pixel(x + i, y + r, c);
+        for (int i = 0; i < w; i++) icon_px(x, y, i, r, c);
     }
 }
 
 static void icon_pause(int x, int y, uint16_t c) {
-    draw_rect_fill(x, y, 3, ICON_SIZE, c);
-    draw_rect_fill(x + 7, y, 3, ICON_SIZE, c);
+    int s = ui_s();
+    draw_rect_fill(x, y, 3 * s, ICON_SIZE * s, c);
+    draw_rect_fill(x + 7 * s, y, 3 * s, ICON_SIZE * s, c);
 }
 
 static void icon_prev(int x, int y, uint16_t c) {
-    draw_rect_fill(x, y, 2, ICON_SIZE, c);
+    int s = ui_s();
+    draw_rect_fill(x, y, 2 * s, ICON_SIZE * s, c);
     for (int r = 0; r < ICON_SIZE; r++) {
         int d = (r < ICON_SIZE / 2) ? r : ICON_SIZE - 1 - r;
         int w = 2 + d * 2;
         if (w > 8) w = 8;
-        for (int i = 0; i < w; i++) draw_pixel(x + ICON_SIZE - 1 - i, y + r, c);
+        for (int i = 0; i < w; i++) icon_px(x, y, ICON_SIZE - 1 - i, r, c);
     }
 }
 
 static void icon_next(int x, int y, uint16_t c) {
+    int s = ui_s();
     for (int r = 0; r < ICON_SIZE; r++) {
         int d = (r < ICON_SIZE / 2) ? r : ICON_SIZE - 1 - r;
         int w = 2 + d * 2;
         if (w > 8) w = 8;
-        for (int i = 0; i < w; i++) draw_pixel(x + i, y + r, c);
+        for (int i = 0; i < w; i++) icon_px(x, y, i, r, c);
     }
-    draw_rect_fill(x + 8, y, 2, ICON_SIZE, c);
+    draw_rect_fill(x + 8 * s, y, 2 * s, ICON_SIZE * s, c);
 }
 
 static void icon_shuffle(int x, int y, uint16_t c) {
     // Two opposing arrows: top points right, bottom points left.
-    for (int i = 0; i < 7; i++) draw_pixel(x + i, y + 2, c);
+    for (int i = 0; i < 7; i++) icon_px(x, y, i, 2, c);
     for (int r = 0; r < 5; r++) {
         int d = (r < 3) ? r : 4 - r;
-        for (int i = 0; i <= d; i++) draw_pixel(x + 6 + i, y + r, c);
+        for (int i = 0; i <= d; i++) icon_px(x, y, 6 + i, r, c);
     }
-    for (int i = 3; i < 10; i++) draw_pixel(x + i, y + 7, c);
+    for (int i = 3; i < 10; i++) icon_px(x, y, i, 7, c);
     for (int r = 0; r < 5; r++) {
         int d = (r < 3) ? r : 4 - r;
-        for (int i = 0; i <= d; i++) draw_pixel(x + 3 - i, y + 5 + r, c);
+        for (int i = 0; i <= d; i++) icon_px(x, y, 3 - i, 5 + r, c);
     }
 }
 
@@ -126,11 +140,15 @@ static void ui_blit_art(int x, int y, int w, int h) {
 }
 
 static void ui_draw_art_framed(int x, int y, int w, int h, const UiPalette *pal) {
+    int s = ui_s();
     if (!art_buffer || w <= 0 || h <= 0) return;
-    draw_rect_fill(x, y + h + 2, w + 4, 2, pal->shadow);
-    draw_rect_fill(x + w + 2, y, 2, h + 2, pal->shadow);
-    draw_rect_outline(x - 1, y - 1, w + 2, h + 2, pal->frame_face);
-    draw_rect_bevel(x - 2, y - 2, w + 4, h + 4, pal->bevel_light, pal->bevel_dark);
+    draw_rect_fill(x, y + h + 2 * s, w + 4 * s, 2 * s, pal->shadow);
+    draw_rect_fill(x + w + 2 * s, y, 2 * s, h + 2 * s, pal->shadow);
+    for (int k = 0; k < s; k++)
+        draw_rect_outline(x - s + k, y - s + k, w + 2 * s - 2 * k, h + 2 * s - 2 * k, pal->frame_face);
+    for (int k = 0; k < s; k++)
+        draw_rect_bevel(x - 2 * s + k, y - 2 * s + k, w + 4 * s - 2 * k, h + 4 * s - 2 * k,
+                        pal->bevel_light, pal->bevel_dark);
     ui_blit_art(x, y, w, h);
 }
 
@@ -160,7 +178,7 @@ static void ui_update_marquee(int *scroll_x, int text_w, int region_x, int regio
         marquee_frac = 0.0f;
         return;
     }
-    marquee_frac += MARQUEE_SPEED_PXS * ui_dt;
+    marquee_frac += MARQUEE_SPEED_PXS * (float)ui_s() * ui_dt;
     int move = (int)marquee_frac;
     if (move > 0) {
         marquee_frac -= (float)move;
@@ -191,59 +209,66 @@ static void ui_draw_debug_overlay(void) {
 }
 
 static void ui_draw_transport(const UiFrame *f, const UiPalette *pal) {
+    int s = ui_s();
     Rect r = layout.icons;
-    int y = r.y + (r.h - ICON_SIZE) / 2;
+    int y = r.y + (r.h - ICON_SIZE * s) / 2;
     int play_x = layout.icon_pause_x;
-    bool trio_fits = r.w >= 58;
+    bool trio_fits = r.w >= 58 * s;
 
     if (trio_fits)
         icon_prev(layout.icon_seek_x, y, (f->seek_dir < 0) ? pal->fg : pal->fg_faint);
     if (f->paused) icon_pause(play_x, y, pal->fg);
     else icon_play(play_x, y, pal->fg);
     if (trio_fits)
-        icon_next(play_x + 24, y, (f->seek_dir > 0) ? pal->fg : pal->fg_faint);
+        icon_next(play_x + 24 * s, y, (f->seek_dir > 0) ? pal->fg : pal->fg_faint);
 
-    if (trio_fits && layout.icon_shuffle_x >= play_x + 24 + ICON_SIZE + 4)
+    if (trio_fits && layout.icon_shuffle_x >= play_x + 24 * s + (ICON_SIZE + 4) * s)
         icon_shuffle(layout.icon_shuffle_x, y, f->shuffle ? pal->fg : pal->fg_faint);
 
     if (f->track_count > 1) {
         char counter[24];
         snprintf(counter, sizeof(counter), "%d/%d", f->track_index + 1, f->track_count);
-        int cw = (int)strlen(counter) * GLYPH_WIDTH;
+        int cw = (int)strlen(counter) * GLYPH_WIDTH * s;
         int cx = r.x + r.w - cw;
-        if (cx >= layout.icon_shuffle_x + ICON_SIZE + 6)
-            draw_text(cx, r.y + (r.h - 8) / 2, counter, pal->fg_faint);
+        if (cx >= layout.icon_shuffle_x + (ICON_SIZE + 6) * s)
+            draw_text_scaled_clipped(cx, r.y + (r.h - 8 * s) / 2, counter, pal->fg_faint, s, 0, fb_width);
     }
 }
 
 static void ui_draw_screen(UiFrame *f, const UiPalette *pal) {
+    int s = ui_s();
+
     if (cfg.show_art && layout.art.w > 0 && layout.art.h > 0)
         ui_draw_art_framed(layout.art.x, layout.art.y, layout.art.w, layout.art.h, pal);
 
     if (cfg.show_viz && layout.viz.w > 0 && layout.viz.h > 0) {
         draw_rect_fill(layout.viz.x, layout.viz.y, layout.viz.w, layout.viz.h, pal->panel);
-        draw_rect_bevel(layout.viz.x, layout.viz.y, layout.viz.w, layout.viz.h,
-                        pal->bevel_dark, pal->bevel_light);
+        for (int k = 0; k < s; k++)
+            draw_rect_bevel(layout.viz.x + k, layout.viz.y + k,
+                            layout.viz.w - 2 * k, layout.viz.h - 2 * k,
+                            pal->bevel_dark, pal->bevel_light);
         viz_draw();
     }
 
     if (cfg.show_txt && layout.text.w > 0) {
-        int scale = (layout.text_scale > 0) ? layout.text_scale : 1;
+        int scale = ((layout.text_scale > 0) ? layout.text_scale : 1) * s;
         int text_w = (int)strlen(display_str) * GLYPH_WIDTH * scale;
         ui_update_marquee(f->scroll_x, text_w, layout.text.x, layout.text.w);
         draw_text_scaled_clipped(*f->scroll_x, layout.text.y, display_str, pal->fg,
                                  scale, layout.text.x, layout.text.w);
     }
 
-    if (cfg.show_bar && f->total_frames > 0 && layout.bar.w > 2 && layout.bar.h > 2) {
-        draw_rect_outline(layout.bar.x, layout.bar.y, layout.bar.w, layout.bar.h, pal->fg_dim);
-        draw_rect_fill(layout.bar.x + 1, layout.bar.y + 1,
-                       layout.bar.w - 2, layout.bar.h - 2, pal->panel);
-        int fill = progress_width(f, layout.bar.w - 2);
+    if (cfg.show_bar && f->total_frames > 0 && layout.bar.w > 2 * s && layout.bar.h > 2 * s) {
+        for (int k = 0; k < s; k++)
+            draw_rect_outline(layout.bar.x + k, layout.bar.y + k,
+                              layout.bar.w - 2 * k, layout.bar.h - 2 * k, pal->fg_dim);
+        draw_rect_fill(layout.bar.x + s, layout.bar.y + s,
+                       layout.bar.w - 2 * s, layout.bar.h - 2 * s, pal->panel);
+        int fill = progress_width(f, layout.bar.w - 2 * s);
         if (fill > 0)
-            draw_rect_fill(layout.bar.x + 1, layout.bar.y + 1, fill, layout.bar.h - 2, pal->fg_dim);
-        int handle_x = layout.bar.x + 1 + ((fill > 2) ? fill - 2 : 0);
-        draw_rect_fill(handle_x, layout.bar.y + 1, 2, layout.bar.h - 2, pal->handle);
+            draw_rect_fill(layout.bar.x + s, layout.bar.y + s, fill, layout.bar.h - 2 * s, pal->fg_dim);
+        int handle_x = layout.bar.x + s + ((fill > 2 * s) ? fill - 2 * s : 0);
+        draw_rect_fill(handle_x, layout.bar.y + s, 2 * s, layout.bar.h - 2 * s, pal->handle);
     }
 
     if (cfg.show_tim && layout.time.w > 0) {
@@ -252,15 +277,15 @@ static void ui_draw_screen(UiFrame *f, const UiPalette *pal) {
         int x0 = (layout.bar.w > 0) ? layout.bar.x : layout.time.x;
         int x1 = (layout.bar.w > 0) ? layout.bar.x + layout.bar.w
                                     : layout.time.x + layout.time.w;
-        draw_text(x0, layout.time.y, elapsed, pal->fg_dim);
+        draw_text_scaled_clipped(x0, layout.time.y, elapsed, pal->fg_dim, s, 0, fb_width);
         if (f->total_frames > 0) {
             char total[16];
             format_time(total, sizeof(total), f->total_frames, f->source_rate);
-            int total_w = (int)strlen(total) * GLYPH_WIDTH;
-            int elapsed_w = (int)strlen(elapsed) * GLYPH_WIDTH;
+            int total_w = (int)strlen(total) * GLYPH_WIDTH * s;
+            int elapsed_w = (int)strlen(elapsed) * GLYPH_WIDTH * s;
             // Skip the total when the row is too narrow for both labels.
-            if (x0 + elapsed_w + GLYPH_WIDTH + total_w <= x1)
-                draw_text(x1 - total_w, layout.time.y, total, pal->fg_dim);
+            if (x0 + elapsed_w + GLYPH_WIDTH * s + total_w <= x1)
+                draw_text_scaled_clipped(x1 - total_w, layout.time.y, total, pal->fg_dim, s, 0, fb_width);
         }
     }
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -92,14 +92,17 @@ static void icon_next(int x, int y, uint16_t c) {
 }
 
 static void icon_shuffle(int x, int y, uint16_t c) {
-    for (int i = 0; i < 9; i++) {
-        draw_pixel(x + i, y + i, c);
-        draw_pixel(x + i, y + 8 - i, c);
+    // Two opposing arrows: top points right, bottom points left.
+    for (int i = 0; i < 7; i++) draw_pixel(x + i, y + 2, c);
+    for (int r = 0; r < 5; r++) {
+        int d = (r < 3) ? r : 4 - r;
+        for (int i = 0; i <= d; i++) draw_pixel(x + 6 + i, y + r, c);
     }
-    draw_pixel(x + 7, y, c);
-    draw_pixel(x + 8, y + 1, c);
-    draw_pixel(x + 7, y + 8, c);
-    draw_pixel(x + 8, y + 7, c);
+    for (int i = 3; i < 10; i++) draw_pixel(x + i, y + 7, c);
+    for (int r = 0; r < 5; r++) {
+        int d = (r < 3) ? r : 4 - r;
+        for (int i = 0; i <= d; i++) draw_pixel(x + 3 - i, y + 5 + r, c);
+    }
 }
 
 static void icon_seek(int x, int y, int dir, uint16_t c) {

--- a/src/ui.c
+++ b/src/ui.c
@@ -237,7 +237,11 @@ static void ui_draw_screen(UiFrame *f, const UiPalette *pal) {
         if (f->total_frames > 0) {
             char total[16];
             format_time(total, sizeof(total), f->total_frames, f->source_rate);
-            draw_text(x1 - (int)strlen(total) * GLYPH_WIDTH, layout.time.y, total, pal->fg_dim);
+            int total_w = (int)strlen(total) * GLYPH_WIDTH;
+            int elapsed_w = (int)strlen(elapsed) * GLYPH_WIDTH;
+            // Skip the total when the row is too narrow for both labels.
+            if (x0 + elapsed_w + GLYPH_WIDTH + total_w <= x1)
+                draw_text(x1 - total_w, layout.time.y, total, pal->fg_dim);
         }
     }
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -17,8 +17,7 @@ typedef struct {
     int *scroll_x;
 } UiFrame;
 
-// Compose one full frame (background, art, visualizer, text, bar, transport)
-// for both the responsive and the manual-offset layout paths.
+// Compose one full frame: background, art, visualizer, text, bar, transport.
 void ui_draw(UiFrame *frame);
 
 // Restart the marquee hold after a track change or state restore.

--- a/src/ui.h
+++ b/src/ui.h
@@ -22,3 +22,6 @@ void ui_draw(UiFrame *frame);
 
 // Restart the marquee hold after a track change or state restore.
 void ui_reset_marquee(void);
+
+// Report the frontend's frame duration so animations advance in real time.
+void ui_set_frame_dt(float dt);

--- a/src/ui.h
+++ b/src/ui.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// Per-frame playback state handed from core.c to the renderer. scroll_x is
+// owned (and serialized) by core.c; ui_draw advances it for the marquee.
+typedef struct {
+    bool paused;
+    bool shuffle;
+    int seek_dir;          // -1 seeking back, 1 seeking forward, 0 idle
+    int track_index;       // 0-based
+    int track_count;
+    uint64_t cur_frame;
+    uint64_t total_frames;
+    uint32_t source_rate;
+    int *scroll_x;
+} UiFrame;
+
+// Compose one full frame (background, art, visualizer, text, bar, transport)
+// for both the responsive and the manual-offset layout paths.
+void ui_draw(UiFrame *frame);
+
+// Restart the marquee hold after a track change or state restore.
+void ui_reset_marquee(void);

--- a/src/video.c
+++ b/src/video.c
@@ -5,14 +5,27 @@
 #include <string.h>
 
 uint16_t *framebuffer = NULL;
+int fb_width = 320;
+int fb_height = 240;
 
 void video_init(void) {
-    framebuffer = malloc(FB_WIDTH * FB_HEIGHT * sizeof(uint16_t));
+    // Allocate at the maximum so resolution switches never reallocate.
+    framebuffer = malloc(FB_MAX_WIDTH * FB_MAX_HEIGHT * sizeof(uint16_t));
     if (!framebuffer) {
         core_log(RETRO_LOG_ERROR, "[MusicCore] Failed to allocate framebuffer\n");
         return;
     }
-    memset(framebuffer, 0, FB_WIDTH * FB_HEIGHT * sizeof(uint16_t));
+    memset(framebuffer, 0, FB_MAX_WIDTH * FB_MAX_HEIGHT * sizeof(uint16_t));
+}
+
+void video_set_resolution(int w, int h) {
+    if (w < 1) w = 1;
+    if (h < 1) h = 1;
+    if (w > FB_MAX_WIDTH) w = FB_MAX_WIDTH;
+    if (h > FB_MAX_HEIGHT) h = FB_MAX_HEIGHT;
+    fb_width = w;
+    fb_height = h;
+    if (framebuffer) memset(framebuffer, 0, FB_MAX_WIDTH * FB_MAX_HEIGHT * sizeof(uint16_t));
 }
 
 void video_deinit(void) {
@@ -22,7 +35,7 @@ void video_deinit(void) {
 
 void video_clear(uint16_t bg_color) {
     if (!framebuffer) return;
-    for (int i = 0; i < FB_WIDTH * FB_HEIGHT; i++) {
+    for (int i = 0; i < fb_width * fb_height; i++) {
         framebuffer[i] = bg_color;
     }
 }
@@ -37,12 +50,12 @@ void video_fill_vgradient(uint16_t top, uint16_t bottom) {
     int tr = ((top >> 11) & 0x1F) << 3, tg = ((top >> 5) & 0x3F) << 2, tb = (top & 0x1F) << 3;
     int br = ((bottom >> 11) & 0x1F) << 3, bg = ((bottom >> 5) & 0x3F) << 2, bb = (bottom & 0x1F) << 3;
 
-    for (int y = 0; y < FB_HEIGHT; y++) {
-        int r8 = tr + ((br - tr) * y) / (FB_HEIGHT - 1);
-        int g8 = tg + ((bg - tg) * y) / (FB_HEIGHT - 1);
-        int b8 = tb + ((bb - tb) * y) / (FB_HEIGHT - 1);
-        uint16_t *row = framebuffer + y * FB_WIDTH;
-        for (int x = 0; x < FB_WIDTH; x++) {
+    for (int y = 0; y < fb_height; y++) {
+        int r8 = tr + ((br - tr) * y) / (fb_height - 1);
+        int g8 = tg + ((bg - tg) * y) / (fb_height - 1);
+        int b8 = tb + ((bb - tb) * y) / (fb_height - 1);
+        uint16_t *row = framebuffer + y * fb_width;
+        for (int x = 0; x < fb_width; x++) {
             int d = bayer[y & 3][x & 3];
             int r = (r8 + (d >> 1)) >> 3;
             int g = (g8 + (d >> 2)) >> 2;
@@ -56,8 +69,8 @@ void video_fill_vgradient(uint16_t top, uint16_t bottom) {
 }
 
 void draw_pixel(int x, int y, uint16_t color) {
-    if (framebuffer && x >= 0 && x < FB_WIDTH && y >= 0 && y < FB_HEIGHT) {
-        framebuffer[y * FB_WIDTH + x] = color;
+    if (framebuffer && x >= 0 && x < fb_width && y >= 0 && y < fb_height) {
+        framebuffer[y * fb_width + x] = color;
     }
 }
 

--- a/src/video.c
+++ b/src/video.c
@@ -27,10 +27,86 @@ void video_clear(uint16_t bg_color) {
     }
 }
 
+void video_fill_vgradient(uint16_t top, uint16_t bottom) {
+    // 4x4 Bayer matrix; offsets scaled to one RGB565 quantum per channel.
+    static const uint8_t bayer[4][4] = {
+        {0, 8, 2, 10}, {12, 4, 14, 6}, {3, 11, 1, 9}, {15, 7, 13, 5}
+    };
+    if (!framebuffer) return;
+
+    int tr = ((top >> 11) & 0x1F) << 3, tg = ((top >> 5) & 0x3F) << 2, tb = (top & 0x1F) << 3;
+    int br = ((bottom >> 11) & 0x1F) << 3, bg = ((bottom >> 5) & 0x3F) << 2, bb = (bottom & 0x1F) << 3;
+
+    for (int y = 0; y < FB_HEIGHT; y++) {
+        int r8 = tr + ((br - tr) * y) / (FB_HEIGHT - 1);
+        int g8 = tg + ((bg - tg) * y) / (FB_HEIGHT - 1);
+        int b8 = tb + ((bb - tb) * y) / (FB_HEIGHT - 1);
+        uint16_t *row = framebuffer + y * FB_WIDTH;
+        for (int x = 0; x < FB_WIDTH; x++) {
+            int d = bayer[y & 3][x & 3];
+            int r = (r8 + (d >> 1)) >> 3;
+            int g = (g8 + (d >> 2)) >> 2;
+            int b = (b8 + (d >> 1)) >> 3;
+            if (r > 31) r = 31;
+            if (g > 63) g = 63;
+            if (b > 31) b = 31;
+            row[x] = (uint16_t)((r << 11) | (g << 5) | b);
+        }
+    }
+}
+
 void draw_pixel(int x, int y, uint16_t color) {
     if (framebuffer && x >= 0 && x < FB_WIDTH && y >= 0 && y < FB_HEIGHT) {
         framebuffer[y * FB_WIDTH + x] = color;
     }
+}
+
+uint16_t mix565(uint16_t a, uint16_t b, int t) {
+    if (t <= 0) return a;
+    if (t >= 256) return b;
+    int ar = (a >> 11) & 0x1F, ag = (a >> 5) & 0x3F, ab = a & 0x1F;
+    int br = (b >> 11) & 0x1F, bg = (b >> 5) & 0x3F, bb = b & 0x1F;
+    int r = ar + (((br - ar) * t) >> 8);
+    int g = ag + (((bg - ag) * t) >> 8);
+    int bl = ab + (((bb - ab) * t) >> 8);
+    return (uint16_t)((r << 11) | (g << 5) | bl);
+}
+
+void draw_rect_fill(int x, int y, int w, int h, uint16_t color) {
+    for (int j = 0; j < h; j++) {
+        for (int i = 0; i < w; i++) draw_pixel(x + i, y + j, color);
+    }
+}
+
+void draw_rect_outline(int x, int y, int w, int h, uint16_t color) {
+    if (w <= 0 || h <= 0) return;
+    int x2 = x + w - 1;
+    int y2 = y + h - 1;
+    for (int px = x; px <= x2; px++) {
+        draw_pixel(px, y, color);
+        draw_pixel(px, y2, color);
+    }
+    for (int py = y; py <= y2; py++) {
+        draw_pixel(x, py, color);
+        draw_pixel(x2, py, color);
+    }
+}
+
+void draw_rect_bevel(int x, int y, int w, int h, uint16_t tl, uint16_t br) {
+    if (w <= 0 || h <= 0) return;
+    int x2 = x + w - 1;
+    int y2 = y + h - 1;
+    for (int px = x; px <= x2; px++) {
+        draw_pixel(px, y, tl);
+        draw_pixel(px, y2, br);
+    }
+    for (int py = y; py <= y2; py++) {
+        draw_pixel(x, py, tl);
+        draw_pixel(x2, py, br);
+    }
+    // Top-right corner belongs to the top edge, bottom-left to the bottom.
+    draw_pixel(x2, y, tl);
+    draw_pixel(x, y2, br);
 }
 
 void draw_text(int x, int y, const char* txt, uint16_t color) {
@@ -50,25 +126,33 @@ void draw_text(int x, int y, const char* txt, uint16_t color) {
 }
 
 void draw_text_clipped(int x, int y, const char* txt, uint16_t color, int clip_x, int clip_w) {
-    if (!txt || clip_w <= 0) return;
+    draw_text_scaled_clipped(x, y, txt, color, 1, clip_x, clip_w);
+}
 
+void draw_text_scaled_clipped(int x, int y, const char* txt, uint16_t color,
+                              int scale, int clip_x, int clip_w) {
+    if (!txt || clip_w <= 0 || scale < 1) return;
+
+    int cell = GLYPH_WIDTH * scale;
     int clip_right = clip_x + clip_w;
     while (*txt) {
         uint8_t c = (*txt++) - 32;
-        int char_left = x;
-        int char_right = x + GLYPH_WIDTH;
 
-        if (char_right > clip_x && char_left < clip_right && c < 96) {
+        if (x + cell > clip_x && x < clip_right && c < 96) {
             for (int gy = 0; gy < 8; gy++) {
                 for (int gx = 0; gx < 8; gx++) {
-                    int px = x + gx;
-                    if (px < clip_x || px >= clip_right) continue;
-                    if (font8x8[c][gy] & (0x80 >> gx))
-                        draw_pixel(px, y + gy, color);
+                    if (!(font8x8[c][gy] & (0x80 >> gx))) continue;
+                    for (int sy = 0; sy < scale; sy++) {
+                        for (int sx = 0; sx < scale; sx++) {
+                            int px = x + gx * scale + sx;
+                            if (px < clip_x || px >= clip_right) continue;
+                            draw_pixel(px, y + gy * scale + sy, color);
+                        }
+                    }
                 }
             }
         }
 
-        x += GLYPH_WIDTH;
+        x += cell;
     }
 }

--- a/src/video.h
+++ b/src/video.h
@@ -2,8 +2,13 @@
 
 #include <stdint.h>
 
-#define FB_WIDTH 320
-#define FB_HEIGHT 240
+// Maximum framebuffer dimensions. The active size is fb_width x fb_height:
+// an integer multiple of 320x240 (1x-4x) chosen by the media_resolution option.
+#define FB_MAX_WIDTH 1280
+#define FB_MAX_HEIGHT 960
+
+extern int fb_width;
+extern int fb_height;
 
 // Glyph cell width of the 8x8 font used by draw_text/draw_text_clipped;
 // text measurement everywhere derives from this.
@@ -17,6 +22,9 @@ void video_init(void);
 
 // Free framebuffer
 void video_deinit(void);
+
+// Select the active output size (clamped to the max); clears the buffer
+void video_set_resolution(int w, int h);
 
 // Clear framebuffer to background color
 void video_clear(uint16_t bg_color);

--- a/src/video.h
+++ b/src/video.h
@@ -21,11 +21,30 @@ void video_deinit(void);
 // Clear framebuffer to background color
 void video_clear(uint16_t bg_color);
 
+// Fill the framebuffer with a vertical top->bottom gradient, ordered-dithered
+// so RGB565 quantization does not band.
+void video_fill_vgradient(uint16_t top, uint16_t bottom);
+
 // Draw a single pixel
 void draw_pixel(int x, int y, uint16_t color);
+
+// Blend two RGB565 colors; t is 0..256 (0 = a, 256 = b)
+uint16_t mix565(uint16_t a, uint16_t b, int t);
+
+// Filled / outlined rectangles
+void draw_rect_fill(int x, int y, int w, int h, uint16_t color);
+void draw_rect_outline(int x, int y, int w, int h, uint16_t color);
+
+// One-pixel bevel edge: top/left in tl, bottom/right in br.
+// Raised look: tl = light, br = dark. Sunken look: swap the two.
+void draw_rect_bevel(int x, int y, int w, int h, uint16_t tl, uint16_t br);
 
 // Draw text using 8x8 font
 void draw_text(int x, int y, const char* txt, uint16_t color);
 
 // Draw text clipped to a horizontal region [clip_x, clip_x + clip_w)
 void draw_text_clipped(int x, int y, const char* txt, uint16_t color, int clip_x, int clip_w);
+
+// Integer-scaled variant of draw_text_clipped (scale 1 = 8px glyphs)
+void draw_text_scaled_clipped(int x, int y, const char* txt, uint16_t color,
+                              int scale, int clip_x, int clip_w);

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -419,9 +419,16 @@ static void draw_line_mode(int band_count) {
             int dy = next_h - h;
 
             for (int step = 0; step < dx; step++) {
-                int interp_y = h + (dy * step) / dx;
-                uint16_t interp_color = cfg.viz_gradient ? get_gradient_color((float)interp_y / (float)max_h) : cfg.fg_rgb;
-                draw_pixel(x + step, base_y - interp_y, interp_color);
+                // Fill the vertical span to the next column so steep slopes
+                // stay connected instead of dissolving into scattered dots.
+                int y0 = h + (dy * step) / dx;
+                int y1 = h + (dy * (step + 1)) / dx;
+                int lo = (y0 < y1) ? y0 : y1;
+                int hi = (y0 > y1) ? y0 : y1;
+                for (int yy = lo; yy <= hi; yy++) {
+                    uint16_t interp_color = cfg.viz_gradient ? get_gradient_color((float)yy / (float)max_h) : cfg.fg_rgb;
+                    draw_pixel(x + step, base_y - yy, interp_color);
+                }
             }
         }
 

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -64,6 +64,9 @@ static int viz_band_x(int band_idx, int band_count, int item_w) {
 }
 
 uint16_t get_gradient_color(float level) {
+    // Clamp: out-of-range input would overflow the uint8_t channel math.
+    if (level < 0.0f) level = 0.0f;
+    if (level > 1.0f) level = 1.0f;
     if (level < 0.5f) {
         // Green (0,255,0) → Yellow (255,255,0)
         float t = level * 2.0f;
@@ -445,8 +448,12 @@ static void draw_dots_mode(int band_count) {
         uint16_t color = cfg.viz_gradient ? get_gradient_color(viz_levels[i]) : cfg.fg_rgb;
 
         // Phosphor trail: older ghost first, both dimmed toward the bg.
+        // Heights are clamped because a layout shrink can leave stale trail
+        // values above the new panel height for a few frames.
         for (int g = 1; g >= 0; g--) {
             int gh = dot_trail[i][g];
+            if (gh > max_h - 1) gh = max_h - 1;
+            if (gh < 0) gh = 0;
             uint16_t gcolor = cfg.viz_gradient ? get_gradient_color((float)gh / (float)max_h) : cfg.fg_rgb;
             gcolor = mix565(gcolor, cfg.bg_rgb, (g == 0) ? 140 : 195);
             draw_dot(x, base_y - gh, gcolor);
@@ -682,8 +689,10 @@ static void draw_mirror_mode(int band_count) {
     if (emblem_w > in.w / 3) emblem_w = in.w / 3;
     int half_avail = (in.w - emblem_w) / 2 - 2 - max_shear;
     if (half_avail < 1) half_avail = 1;
-    if (band_count > half_avail) band_count = half_avail;
-    int spacing = half_avail / band_count;
+    // Narrow panels decimate evenly across the spectrum instead of silently
+    // truncating the treble bands away.
+    int draw_bands = (band_count > half_avail) ? half_avail : band_count;
+    int spacing = half_avail / draw_bands;
     if (spacing < 1) spacing = 1;
     int bar_w = spacing - 1;
     if (bar_w < 1) bar_w = 1;
@@ -691,8 +700,9 @@ static void draw_mirror_mode(int band_count) {
 
     for (int x = 0; x < in.w; x++) draw_pixel(in.x + x, base_y, horizon);
 
-    for (int i = 0; i < band_count; i++) {
-        int h = (int)(viz_levels[i] * max_h);
+    for (int i = 0; i < draw_bands; i++) {
+        int src = i * band_count / draw_bands;
+        int h = (int)(viz_levels[src] * max_h);
         if (h > max_h) h = max_h;
         int off0 = emblem_w / 2 + 2 + i * spacing;
 
@@ -722,8 +732,8 @@ static void draw_mirror_mode(int band_count) {
                     draw_pixel(bx + dir * w, base_y + 1 + v, color);
             }
 
-            if (cfg.viz_peak_hold > 0 && viz_peak_timers[i] > 0) {
-                int ph = (int)(viz_peaks[i] * max_h);
+            if (cfg.viz_peak_hold > 0 && viz_peak_timers[src] > 0) {
+                int ph = (int)(viz_peaks[src] * max_h);
                 if (ph >= max_h) ph = max_h - 1;
                 int bx = cx + dir * (off0 + ph / 6);
                 uint16_t pc = cfg.viz_gradient ? 0xF800 : cfg.fg_rgb;

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -30,9 +30,7 @@ static float fft_ring[FFT_SIZE] = {0};
 static int fft_ring_pos = 0;
 static int fft_ring_count = 0;
 
-static int viz_band_x(int band_idx, int band_count, int item_w, int start_x, int spacing) {
-    if (!cfg.responsive) return start_x + (band_idx * spacing);
-
+static int viz_band_x(int band_idx, int band_count, int item_w) {
     if (item_w < 1) item_w = 1;
     if (item_w > layout.viz_inner.w) item_w = layout.viz_inner.w;
     if (layout.viz_inner.w <= item_w) return layout.viz_inner.x;
@@ -338,34 +336,18 @@ void viz_update_levels(const int16_t *audio_buf, int samples_per_frame) {
 }
 
 static void draw_bars_mode(int band_count) {
-    int start_x;
-    int bar_width;
-    int spacing;
-    int max_h;
-    int base_y;
-
-    if (cfg.responsive) {
-        start_x = layout.viz_start_x;
-        bar_width = layout.viz_bar_width;
-        spacing = layout.viz_spacing;
-        max_h = layout.viz_max_h;
-        base_y = layout.viz_inner.y + layout.viz_inner.h - 1;
-    } else {
-        start_x = (band_count == 40) ? 80 : 100;
-        bar_width = (band_count == 40) ? 2 : 4;
-        spacing = (band_count == 40) ? 4 : 6;
-        max_h = 35;
-        base_y = cfg.viz_y;
-    }
+    int max_h = layout.viz_max_h;
+    int base_y = layout.viz_inner.y + layout.viz_inner.h - 1;
     if (max_h < 1) max_h = 1;
 
-    int draw_bar_width = bar_width;
-    if (cfg.responsive && draw_bar_width > layout.viz_inner.w) draw_bar_width = layout.viz_inner.w;
+    int draw_bar_width = layout.viz_bar_width;
+    if (draw_bar_width > layout.viz_inner.w) draw_bar_width = layout.viz_inner.w;
+    if (draw_bar_width < 1) draw_bar_width = 1;
 
     for (int i = 0; i < band_count; i++) {
         int h = (int)(viz_levels[i] * max_h);
         if (h > max_h) h = max_h;
-        int x_base = viz_band_x(i, band_count, draw_bar_width, start_x, spacing);
+        int x_base = viz_band_x(i, band_count, draw_bar_width);
 
         // Draw main bar
         for (int v = 0; v < h; v++) {
@@ -387,41 +369,14 @@ static void draw_bars_mode(int band_count) {
 }
 
 static void draw_dots_mode(int band_count) {
-    int start_x;
-    int spacing;
-    int max_h;
-    int base_y;
-
-    if (cfg.responsive) {
-        spacing = layout.viz_spacing;
-        max_h = layout.viz_max_h;
-        base_y = layout.viz_inner.y + layout.viz_inner.h - 1;
-        if (spacing < 2) spacing = 2;
-
-        // Keep 2x2 dots inside the responsive visualizer bounds.
-        if (band_count > 1) {
-            int dots_w = spacing * (band_count - 1) + 2;
-            if (dots_w > layout.viz_inner.w) {
-                spacing = (layout.viz_inner.w - 2) / (band_count - 1);
-                if (spacing < 1) spacing = 1;
-                dots_w = spacing * (band_count - 1) + 2;
-            }
-            start_x = layout.viz_inner.x + (layout.viz_inner.w - dots_w) / 2;
-        } else {
-            start_x = layout.viz_inner.x + (layout.viz_inner.w - 2) / 2;
-        }
-    } else {
-        start_x = (band_count == 40) ? 100 : 130;
-        spacing = (band_count == 40) ? 3 : 4;
-        max_h = 50;
-        base_y = cfg.viz_y;
-    }
+    int max_h = layout.viz_max_h;
+    int base_y = layout.viz_inner.y + layout.viz_inner.h - 1;
     if (max_h < 1) max_h = 1;
 
     for (int i = 0; i < band_count; i++) {
         int h = (int)(viz_levels[i] * max_h);
         if (h >= max_h) h = max_h - 1;
-        int x = viz_band_x(i, band_count, 2, start_x, spacing);
+        int x = viz_band_x(i, band_count, 2);
         uint16_t color = cfg.viz_gradient ? get_gradient_color(viz_levels[i]) : cfg.fg_rgb;
 
         // Draw 2x2 dot
@@ -442,28 +397,14 @@ static void draw_dots_mode(int band_count) {
 }
 
 static void draw_line_mode(int band_count) {
-    int start_x;
-    int spacing;
-    int max_h;
-    int base_y;
-
-    if (cfg.responsive) {
-        start_x = layout.viz_start_x;
-        spacing = layout.viz_spacing;
-        max_h = layout.viz_max_h;
-        base_y = layout.viz_inner.y + layout.viz_inner.h - 1;
-    } else {
-        start_x = (band_count == 40) ? 80 : 100;
-        spacing = (band_count == 40) ? 4 : 6;
-        max_h = 40;
-        base_y = cfg.viz_y;
-    }
+    int max_h = layout.viz_max_h;
+    int base_y = layout.viz_inner.y + layout.viz_inner.h - 1;
     if (max_h < 1) max_h = 1;
 
     for (int i = 0; i < band_count; i++) {
         int h = (int)(viz_levels[i] * max_h);
         if (h >= max_h) h = max_h - 1;
-        int x = viz_band_x(i, band_count, 1, start_x, spacing);
+        int x = viz_band_x(i, band_count, 1);
         uint16_t color = cfg.viz_gradient ? get_gradient_color(viz_levels[i]) : cfg.fg_rgb;
 
         // Draw vertical line
@@ -473,7 +414,7 @@ static void draw_line_mode(int band_count) {
         if (i < band_count - 1) {
             int next_h = (int)(viz_levels[i + 1] * max_h);
             if (next_h >= max_h) next_h = max_h - 1;
-            int next_x = viz_band_x(i + 1, band_count, 1, start_x, spacing);
+            int next_x = viz_band_x(i + 1, band_count, 1);
             int dx = next_x - x;
             int dy = next_h - h;
 
@@ -495,33 +436,28 @@ static void draw_line_mode(int band_count) {
 }
 
 static void draw_vu_meter_mode(void) {
-    int label_x = 80;
-    int meter_x = 95;
-    int meter_w = 180;
     const int meter_h = 4;
     const int meter_gap = 4;
     const int label_h = 8;
     const int row_step = (meter_h + meter_gap > label_h) ? (meter_h + meter_gap) : label_h;
     const int pair_h = row_step + label_h;
-    int left_y = cfg.viz_y - 15;
-    int right_y = left_y + row_step;
 
-    if (cfg.responsive) {
-        meter_w = layout.viz_meter_w;
-        if (meter_w < 1) meter_w = 1;
-        meter_x = layout.viz_inner.x + (layout.viz_inner.w - meter_w);
-        label_x = layout.viz_inner.x;
+    int meter_w = layout.viz_meter_w;
+    if (meter_w < 1) meter_w = 1;
+    int meter_x = layout.viz_inner.x + (layout.viz_inner.w - meter_w);
+    int label_x = layout.viz_inner.x;
+    int left_y;
+    int right_y;
 
-        if (layout.viz_inner.h >= pair_h) {
-            int pair_top = layout.viz_inner.y + (layout.viz_inner.h - pair_h) / 2;
-            left_y = pair_top;
-            right_y = pair_top + row_step;
-        } else {
-            // Too short for two meters, show only left as a mono meter
-            left_y = layout.viz_inner.y + (layout.viz_inner.h - meter_h) / 2;
-            if (left_y < layout.viz_inner.y) left_y = layout.viz_inner.y;
-            right_y = -1;
-        }
+    if (layout.viz_inner.h >= pair_h) {
+        int pair_top = layout.viz_inner.y + (layout.viz_inner.h - pair_h) / 2;
+        left_y = pair_top;
+        right_y = pair_top + row_step;
+    } else {
+        // Too short for two meters, show only left as a mono meter
+        left_y = layout.viz_inner.y + (layout.viz_inner.h - meter_h) / 2;
+        if (left_y < layout.viz_inner.y) left_y = layout.viz_inner.y;
+        right_y = -1;
     }
 
     // Draw Left meter
@@ -574,7 +510,7 @@ void viz_reset_state(void) {
 
 void viz_draw(void) {
     int band_count = cfg.viz_bands;
-    if (cfg.responsive && (layout.viz_inner.w <= 0 || layout.viz_inner.h <= 0)) return;
+    if (layout.viz_inner.w <= 0 || layout.viz_inner.h <= 0) return;
 
     if (cfg.viz_mode == VIZ_MODE_BARS || cfg.viz_mode == VIZ_MODE_FFT_EQ_LEGACY) {
         draw_bars_mode(band_count);

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -15,6 +15,13 @@ int viz_peak_timers[MAX_VIZ_BANDS] = {0};
 static int dot_trail[MAX_VIZ_BANDS][2] = {{0}};
 static int dot_trail_tick = 0;
 
+// Horizon mode: ring of recent spectrum rows forming a 3D landscape; the
+// newest ridge stands at the front and history recedes into fog.
+#define HORIZON_ROWS 24
+static float horizon_hist[HORIZON_ROWS][MAX_VIZ_BANDS] = {{0}};
+static int horizon_head = 0;
+static int horizon_tick = 0;
+
 // Scope mode: raw mono sample ring plus per-column afterglow traces.
 #define SCOPE_RING 2048
 #define SCOPE_SPAN 800            // ~17ms window at 48kHz
@@ -292,6 +299,14 @@ static void fft_update_levels(const int16_t *audio_buf, int samples_per_frame, i
     for (int i = band_count; i < MAX_VIZ_BANDS; i++) {
         viz_decay_band(i);
         fft_noise_floor[i] *= 0.995f;
+    }
+
+    // Feed the Horizon landscape history every other frame.
+    horizon_tick ^= 1;
+    if (horizon_tick == 0) {
+        horizon_head = (horizon_head + 1) % HORIZON_ROWS;
+        for (int i = 0; i < MAX_VIZ_BANDS; i++)
+            horizon_hist[horizon_head][i] = (i < band_count) ? viz_levels[i] : 0.0f;
     }
 }
 
@@ -744,12 +759,77 @@ static void draw_mirror_mode(int band_count) {
     }
 }
 
+// 3D spectrum landscape, drawn back to front (painter's algorithm). Each row
+// is a ridge: a bright line over a dark body fill that occludes rows behind
+// it, with perspective shrink and fog toward the horizon.
+static void draw_horizon_mode(int band_count) {
+    Rect in = layout.viz_inner;
+    if (band_count < 2) band_count = 2;
+
+    uint16_t panel = mix565(cfg.bg_rgb, 0x0000, 150);
+
+    int cx = in.x + in.w / 2;
+    int front_y = in.y + in.h - 2;
+    int back_y = in.y + (in.h * 2) / 5;
+    if (back_y >= front_y) back_y = front_y - 1;
+    int ridge_max = (in.h * 11) / 20;
+    if (ridge_max < 2) ridge_max = 2;
+
+    const float persp_back = 1.0f / (1.0f + 2.4f);
+
+    for (int a = HORIZON_ROWS - 1; a >= 0; a--) {
+        const float *row = horizon_hist[(horizon_head - a + HORIZON_ROWS) % HORIZON_ROWS];
+        float t = (float)a / (float)(HORIZON_ROWS - 1);
+        float persp = 1.0f / (1.0f + 2.4f * t);
+        int baseline = front_y - (int)((float)(front_y - back_y) * (1.0f - persp) / (1.0f - persp_back));
+        int hw = (int)((float)(in.w / 2 - 2) * (0.35f + 0.65f * persp));
+        if (hw < 4) hw = 4;
+        int fog = (int)(t * 185.0f);
+        float rise = (float)ridge_max * persp;
+
+        int prev_x = cx - hw;
+        int prev_y = baseline - (int)(row[0] * rise);
+        for (int i = 1; i <= band_count; i++) {
+            int px, py;
+            if (i < band_count) {
+                px = cx - hw + (2 * hw * i) / (band_count - 1);
+                py = baseline - (int)(row[i] * rise);
+            } else {
+                px = prev_x + 1;   // close out the rightmost column
+                py = prev_y;
+            }
+            int dx = px - prev_x;
+            if (dx < 1) dx = 1;
+            for (int step = 0; step < dx; step++) {
+                int col = prev_x + step;
+                int y0 = prev_y + ((py - prev_y) * step) / dx;
+                int y1 = prev_y + ((py - prev_y) * (step + 1)) / dx;
+                int lo = (y0 < y1) ? y0 : y1;
+                int hi = (y0 > y1) ? y0 : y1;
+                float lvl = (float)(baseline - lo) / (rise + 0.001f);
+                if (lvl < 0.0f) lvl = 0.0f;
+                if (lvl > 1.0f) lvl = 1.0f;
+                uint16_t line_c = cfg.viz_gradient ? get_gradient_color(lvl) : cfg.fg_rgb;
+                line_c = mix565(line_c, panel, fog);
+                uint16_t body_c = mix565(panel, line_c, 70);
+                for (int yy = hi + 1; yy <= baseline; yy++) draw_pixel(col, yy, body_c);
+                for (int yy = lo; yy <= hi; yy++) draw_pixel(col, yy, line_c);
+            }
+            prev_x = px;
+            prev_y = py;
+        }
+    }
+}
+
 void viz_reset_state(void) {
     memset(viz_levels, 0, sizeof(viz_levels));
     memset(viz_peaks, 0, sizeof(viz_peaks));
     memset(viz_peak_timers, 0, sizeof(viz_peak_timers));
     memset(dot_trail, 0, sizeof(dot_trail));
     dot_trail_tick = 0;
+    memset(horizon_hist, 0, sizeof(horizon_hist));
+    horizon_head = 0;
+    horizon_tick = 0;
     memset(scope_ring, 0, sizeof(scope_ring));
     scope_ring_pos = 0;
     memset(scope_ghost_lo, 0, sizeof(scope_ghost_lo));
@@ -784,5 +864,7 @@ void viz_draw(void) {
         draw_scope_mode();
     } else if (cfg.viz_mode == VIZ_MODE_MIRROR) {
         draw_mirror_mode(band_count);
+    } else if (cfg.viz_mode == VIZ_MODE_HORIZON) {
+        draw_horizon_mode(band_count);
     }
 }

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -11,7 +11,9 @@ float viz_levels[MAX_VIZ_BANDS] = {0};
 float viz_peaks[MAX_VIZ_BANDS] = {0};
 int viz_peak_timers[MAX_VIZ_BANDS] = {0};
 
-#define FFT_SIZE 1024
+// 2048 points at 48kHz gives ~23Hz bins so the low log-spaced bands stop
+// sharing bins; the analysis window grows to ~43ms, fine for a visualizer.
+#define FFT_SIZE 2048
 #define TWO_PI_F 6.28318530717958647692f
 #define FFT_MIN_FREQ 35.0f
 #define FFT_MAX_FREQ_RATIO 0.92f
@@ -173,7 +175,7 @@ static void fft_update_levels(const int16_t *audio_buf, int samples_per_frame, i
         return;
     }
 
-    float mono_samples[FFT_SIZE];
+    static float mono_samples[FFT_SIZE];  // 8KB; keep off the frontend's stack
     float dc_sum = 0.0f;
     int ring_idx = fft_ring_pos;
     for (int i = 0; i < FFT_SIZE; i++) {

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -429,8 +429,9 @@ static void draw_line_mode(int band_count) {
         if (cfg.viz_peak_hold > 0 && viz_peak_timers[i] > 0) {
             int peak_h = (int)(viz_peaks[i] * max_h);
             if (peak_h >= max_h) peak_h = max_h - 1;
-            draw_pixel(x, base_y - peak_h, 0xF800);
-            draw_pixel(x + 1, base_y - peak_h, 0xF800);
+            uint16_t peak_color = cfg.viz_gradient ? 0xF800 : cfg.fg_rgb;
+            draw_pixel(x, base_y - peak_h, peak_color);
+            draw_pixel(x + 1, base_y - peak_h, peak_color);
         }
     }
 }
@@ -468,10 +469,11 @@ static void draw_vu_meter_mode(void) {
         uint16_t color = cfg.viz_gradient ? get_gradient_color((float)x / (float)meter_w) : cfg.fg_rgb;
         for (int y = 0; y < meter_h; y++) draw_pixel(meter_x + x, left_y + y, color);
     }
+    uint16_t peak_color = cfg.viz_gradient ? 0xF800 : cfg.fg_rgb;
     if (cfg.viz_peak_hold > 0 && viz_peak_timers[0] > 0) {
         int peak_x = (int)(viz_peaks[0] * meter_w);
         if (peak_x >= meter_w) peak_x = meter_w - 1;
-        for (int y = 0; y < meter_h; y++) draw_pixel(meter_x + peak_x, left_y + y, 0xF800);
+        for (int y = 0; y < meter_h; y++) draw_pixel(meter_x + peak_x, left_y + y, peak_color);
     }
 
     // Draw Right meter (skip if too short for two meters)
@@ -486,7 +488,7 @@ static void draw_vu_meter_mode(void) {
         if (cfg.viz_peak_hold > 0 && viz_peak_timers[1] > 0) {
             int peak_x = (int)(viz_peaks[1] * meter_w);
             if (peak_x >= meter_w) peak_x = meter_w - 1;
-            for (int y = 0; y < meter_h; y++) draw_pixel(meter_x + peak_x, right_y + y, 0xF800);
+            for (int y = 0; y < meter_h; y++) draw_pixel(meter_x + peak_x, right_y + y, peak_color);
         }
     }
 }

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -343,14 +343,20 @@ static void draw_bars_mode(int band_count) {
     if (draw_bar_width > layout.viz_inner.w) draw_bar_width = layout.viz_inner.w;
     if (draw_bar_width < 1) draw_bar_width = 1;
 
+    uint16_t unlit_color = mix565(cfg.bg_rgb, cfg.fg_rgb, 28);
+
     for (int i = 0; i < band_count; i++) {
         int h = (int)(viz_levels[i] * max_h);
         if (h > max_h) h = max_h;
         int x_base = viz_band_x(i, band_count, draw_bar_width);
 
-        // Draw main bar
-        for (int v = 0; v < h; v++) {
-            uint16_t color = cfg.viz_gradient ? get_gradient_color((float)v / (float)max_h) : cfg.fg_rgb;
+        // LED ladder: 2px lit segments with 1px gaps; segments above the
+        // level stay faintly visible so the ladder reads as hardware.
+        for (int v = 0; v < max_h; v++) {
+            if ((v % 3) == 2) continue;
+            uint16_t color;
+            if (v < h) color = cfg.viz_gradient ? get_gradient_color((float)v / (float)max_h) : cfg.fg_rgb;
+            else color = unlit_color;
             for (int w = 0; w < draw_bar_width; w++) draw_pixel(x_base + w, base_y - v, color);
         }
 

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -642,6 +642,108 @@ static void draw_scope_mode(void) {
     }
 }
 
+// Kenwood-style mirrored spectrum: bands fan out from a center emblem with an
+// outward shear, LED-segmented, over a horizon line with a dimmed reflection.
+static void draw_mirror_mode(int band_count) {
+    Rect in = layout.viz_inner;
+    int cx = in.x + in.w / 2;
+
+    uint16_t panel = mix565(cfg.bg_rgb, 0x0000, 150);
+    uint16_t unlit = mix565(panel, cfg.fg_rgb, 16);
+    uint16_t horizon = mix565(panel, cfg.fg_rgb, 40);
+
+    // Bars rise from a horizon line; the reflection lives below it.
+    int up_h = (in.h * 5) / 8;
+    if (up_h < 6) up_h = 6;
+    if (up_h > in.h - 1) up_h = in.h - 1;
+    int base_y = in.y + up_h;
+    int refl_h = in.y + in.h - base_y - 1;
+    if (refl_h < 0) refl_h = 0;
+    int max_h = up_h - 1;
+    if (max_h < 1) max_h = 1;
+    int max_shear = max_h / 6;
+
+    int emblem_w = 30;
+    if (emblem_w > in.w / 3) emblem_w = in.w / 3;
+    int half_avail = (in.w - emblem_w) / 2 - 2 - max_shear;
+    if (half_avail < 1) half_avail = 1;
+    if (band_count > half_avail) band_count = half_avail;
+    int spacing = half_avail / band_count;
+    if (spacing < 1) spacing = 1;
+    int bar_w = spacing - 1;
+    if (bar_w < 1) bar_w = 1;
+    if (bar_w > 4) bar_w = 4;
+
+    for (int x = 0; x < in.w; x++) draw_pixel(in.x + x, base_y, horizon);
+
+    for (int i = 0; i < band_count; i++) {
+        int h = (int)(viz_levels[i] * max_h);
+        if (h > max_h) h = max_h;
+        int off0 = emblem_w / 2 + 2 + i * spacing;
+
+        for (int side = 0; side < 2; side++) {
+            int dir = side ? -1 : 1;
+
+            // LED ladder leaning outward: shear grows with height.
+            for (int v = 0; v < max_h; v++) {
+                if ((v % 3) == 2) continue;
+                int bx = cx + dir * (off0 + v / 6);
+                uint16_t color = (v < h)
+                    ? (cfg.viz_gradient ? get_gradient_color((float)v / (float)max_h) : cfg.fg_rgb)
+                    : unlit;
+                for (int w = 0; w < bar_w; w++)
+                    draw_pixel(bx + dir * w, base_y - 1 - v, color);
+            }
+
+            // Reflection: lit segments only, half height, dimmed toward panel.
+            int rh = h / 2;
+            if (rh > refl_h) rh = refl_h;
+            for (int v = 0; v < rh; v++) {
+                if ((v % 3) == 2) continue;
+                int bx = cx + dir * (off0 + (v * 2) / 6);
+                uint16_t src = cfg.viz_gradient ? get_gradient_color((float)(v * 2) / (float)max_h) : cfg.fg_rgb;
+                uint16_t color = mix565(src, panel, 150);
+                for (int w = 0; w < bar_w; w++)
+                    draw_pixel(bx + dir * w, base_y + 1 + v, color);
+            }
+
+            if (cfg.viz_peak_hold > 0 && viz_peak_timers[i] > 0) {
+                int ph = (int)(viz_peaks[i] * max_h);
+                if (ph >= max_h) ph = max_h - 1;
+                int bx = cx + dir * (off0 + ph / 6);
+                uint16_t pc = cfg.viz_gradient ? 0xF800 : cfg.fg_rgb;
+                for (int w = 0; w < bar_w; w++)
+                    draw_pixel(bx + dir * w, base_y - 1 - ph, pc);
+            }
+        }
+    }
+
+    // Center emblem: a bass-pulsing diamond crest — a dim outline ring with a
+    // solid core that grows and heats up with the low bands.
+    float bass = (viz_levels[0] + viz_levels[1] + viz_levels[2]) / 3.0f;
+    int es = 18 + (int)(bass * 8.0f);
+    if (es > emblem_w - 2) es = emblem_w - 2;
+    if (es > up_h - 2) es = up_h - 2;
+    if (es >= 6) {
+        int r = es / 2;
+        int my = in.y + (up_h - es) / 2 + r;
+        uint16_t ring = mix565(panel, cfg.fg_rgb, 80);
+        uint16_t core = cfg.viz_gradient ? get_gradient_color(bass) : cfg.fg_rgb;
+
+        for (int dy = -r; dy <= r; dy++) {
+            int wl = r - ((dy < 0) ? -dy : dy);
+            draw_pixel(cx - wl, my + dy, ring);
+            draw_pixel(cx + wl, my + dy, ring);
+        }
+        int rc = r - 3;
+        if (rc < 1) rc = 1;
+        for (int dy = -rc; dy <= rc; dy++) {
+            int wl = rc - ((dy < 0) ? -dy : dy);
+            for (int dx = -wl; dx <= wl; dx++) draw_pixel(cx + dx, my + dy, core);
+        }
+    }
+}
+
 void viz_reset_state(void) {
     memset(viz_levels, 0, sizeof(viz_levels));
     memset(viz_peaks, 0, sizeof(viz_peaks));
@@ -680,5 +782,7 @@ void viz_draw(void) {
         draw_vu_meter_mode();
     } else if (cfg.viz_mode == VIZ_MODE_SCOPE) {
         draw_scope_mode();
+    } else if (cfg.viz_mode == VIZ_MODE_MIRROR) {
+        draw_mirror_mode(band_count);
     }
 }

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -11,16 +11,25 @@ float viz_levels[MAX_VIZ_BANDS] = {0};
 float viz_peaks[MAX_VIZ_BANDS] = {0};
 int viz_peak_timers[MAX_VIZ_BANDS] = {0};
 
+// Frame duration from the frontend (60fps fallback); paces the trail/ghost/
+// history cadences and the VU integration in real time.
+static float viz_dt = 1.0f / 60.0f;
+#define VIZ_CADENCE_SEC (1.0f / 30.0f)
+
+void viz_set_frame_dt(float dt) {
+    viz_dt = dt;
+}
+
 // Dots-mode phosphor trail: previous dot heights, most recent first.
 static int dot_trail[MAX_VIZ_BANDS][2] = {{0}};
-static int dot_trail_tick = 0;
+static float dot_trail_acc = 0.0f;
 
 // Horizon mode: ring of recent spectrum rows forming a 3D landscape; the
 // newest ridge stands at the front and history recedes into fog.
 #define HORIZON_ROWS 24
 static float horizon_hist[HORIZON_ROWS][MAX_VIZ_BANDS] = {{0}};
 static int horizon_head = 0;
-static int horizon_tick = 0;
+static float horizon_acc = 0.0f;
 
 // Scope mode: raw mono sample ring plus per-column afterglow traces.
 #define SCOPE_RING 2048
@@ -30,7 +39,7 @@ static int16_t scope_ring[SCOPE_RING] = {0};
 static int scope_ring_pos = 0;
 static int16_t scope_ghost_lo[2][FB_WIDTH] = {{0}};
 static int16_t scope_ghost_hi[2][FB_WIDTH] = {{0}};
-static int scope_ghost_tick = 0;
+static float scope_ghost_acc = 0.0f;
 
 // 2048 points at 48kHz gives ~23Hz bins so the low log-spaced bands stop
 // sharing bins; the analysis window grows to ~43ms, fine for a visualizer.
@@ -304,9 +313,11 @@ static void fft_update_levels(const int16_t *audio_buf, int samples_per_frame, i
         fft_noise_floor[i] *= 0.995f;
     }
 
-    // Feed the Horizon landscape history every other frame.
-    horizon_tick ^= 1;
-    if (horizon_tick == 0) {
+    // Feed the Horizon landscape history at a fixed real-time cadence.
+    horizon_acc += viz_dt;
+    if (horizon_acc >= VIZ_CADENCE_SEC) {
+        horizon_acc -= VIZ_CADENCE_SEC;
+        if (horizon_acc > VIZ_CADENCE_SEC) horizon_acc = 0.0f;
         horizon_head = (horizon_head + 1) % HORIZON_ROWS;
         for (int i = 0; i < MAX_VIZ_BANDS; i++)
             horizon_hist[horizon_head][i] = (i < band_count) ? viz_levels[i] : 0.0f;
@@ -343,9 +354,11 @@ static void vu_update_levels(const int16_t *audio_buf, int samples_per_frame, in
         right_target = vu_db_level(sqrtf(right_sq / (float)level_samples));
     }
 
-    // ~150ms integration in both directions for the analog needle feel.
-    viz_levels[0] = viz_levels[0] * 0.88f + left_target * 0.12f;
-    viz_levels[1] = viz_levels[1] * 0.88f + right_target * 0.12f;
+    // ~150ms integration in both directions for the analog needle feel,
+    // converted to real time so the ballistics match on non-60Hz hosts.
+    float k = 1.0f - powf(0.88f, viz_dt * 60.0f);
+    viz_levels[0] += (left_target - viz_levels[0]) * k;
+    viz_levels[1] += (right_target - viz_levels[1]) * k;
 
     viz_update_peak(0);
     viz_update_peak(1);
@@ -437,9 +450,15 @@ static void draw_dots_mode(int band_count) {
     int base_y = layout.viz_inner.y + layout.viz_inner.h - 1;
     if (max_h < 1) max_h = 1;
 
-    // Record ghost positions every other frame so the trail visibly lags.
-    dot_trail_tick ^= 1;
-    int record = (dot_trail_tick == 0);
+    // Record ghost positions at a fixed real-time cadence so the trail lag
+    // reads the same on any host refresh rate.
+    dot_trail_acc += viz_dt;
+    int record = 0;
+    if (dot_trail_acc >= VIZ_CADENCE_SEC) {
+        record = 1;
+        dot_trail_acc -= VIZ_CADENCE_SEC;
+        if (dot_trail_acc > VIZ_CADENCE_SEC) dot_trail_acc = 0.0f;
+    }
 
     for (int i = 0; i < band_count; i++) {
         int h = (int)(viz_levels[i] * max_h);
@@ -631,8 +650,13 @@ static void draw_scope_mode(void) {
         }
     }
 
-    scope_ghost_tick ^= 1;
-    int record = (scope_ghost_tick == 0);
+    scope_ghost_acc += viz_dt;
+    int record = 0;
+    if (scope_ghost_acc >= VIZ_CADENCE_SEC) {
+        record = 1;
+        scope_ghost_acc -= VIZ_CADENCE_SEC;
+        if (scope_ghost_acc > VIZ_CADENCE_SEC) scope_ghost_acc = 0.0f;
+    }
 
     for (int x = 0; x < w; x++) {
         int s0 = win + (x * SCOPE_SPAN) / w;
@@ -836,15 +860,15 @@ void viz_reset_state(void) {
     memset(viz_peaks, 0, sizeof(viz_peaks));
     memset(viz_peak_timers, 0, sizeof(viz_peak_timers));
     memset(dot_trail, 0, sizeof(dot_trail));
-    dot_trail_tick = 0;
+    dot_trail_acc = 0.0f;
     memset(horizon_hist, 0, sizeof(horizon_hist));
     horizon_head = 0;
-    horizon_tick = 0;
+    horizon_acc = 0.0f;
     memset(scope_ring, 0, sizeof(scope_ring));
     scope_ring_pos = 0;
     memset(scope_ghost_lo, 0, sizeof(scope_ghost_lo));
     memset(scope_ghost_hi, 0, sizeof(scope_ghost_hi));
-    scope_ghost_tick = 0;
+    scope_ghost_acc = 0.0f;
     memset(fft_re, 0, sizeof(fft_re));
     memset(fft_im, 0, sizeof(fft_im));
     memset(fft_band_energy, 0, sizeof(fft_band_energy));

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -20,6 +20,12 @@ void viz_set_frame_dt(float dt) {
     viz_dt = dt;
 }
 
+// Resolution scale (1x = 320x240, 2x = 640x480): pixel-sized details are
+// authored at 1x and multiplied so the modes read identically when scaled.
+static int viz_s(void) {
+    return (cfg.ui_scale > 0) ? cfg.ui_scale : 1;
+}
+
 // Dots-mode phosphor trail: previous dot heights, most recent first.
 static int dot_trail[MAX_VIZ_BANDS][2] = {{0}};
 static float dot_trail_acc = 0.0f;
@@ -37,8 +43,8 @@ static float horizon_acc = 0.0f;
 #define SCOPE_TRIGGER_SEARCH 480  // rising-zero-crossing hunt range
 static int16_t scope_ring[SCOPE_RING] = {0};
 static int scope_ring_pos = 0;
-static int16_t scope_ghost_lo[2][FB_WIDTH] = {{0}};
-static int16_t scope_ghost_hi[2][FB_WIDTH] = {{0}};
+static int16_t scope_ghost_lo[2][FB_MAX_WIDTH] = {{0}};
+static int16_t scope_ghost_hi[2][FB_MAX_WIDTH] = {{0}};
 static float scope_ghost_acc = 0.0f;
 
 // 2048 points at 48kHz gives ~23Hz bins so the low log-spaced bands stop
@@ -408,6 +414,7 @@ static void draw_bars_mode(int band_count) {
 
     // Unlit segments sit just above the sunken panel shade (ui_palette mixes
     // the panel at bg->black 150), not the brighter screen background.
+    int s = viz_s();
     uint16_t unlit_color = mix565(mix565(cfg.bg_rgb, 0x0000, 150), cfg.fg_rgb, 16);
 
     for (int i = 0; i < band_count; i++) {
@@ -415,10 +422,10 @@ static void draw_bars_mode(int band_count) {
         if (h > max_h) h = max_h;
         int x_base = viz_band_x(i, band_count, draw_bar_width);
 
-        // LED ladder: 2px lit segments with 1px gaps; segments above the
-        // level stay faintly visible so the ladder reads as hardware.
+        // LED ladder: 2-unit lit segments with 1-unit gaps; segments above
+        // the level stay faintly visible so the ladder reads as hardware.
         for (int v = 0; v < max_h; v++) {
-            if ((v % 3) == 2) continue;
+            if (((v / s) % 3) == 2) continue;
             uint16_t color;
             if (v < h) color = cfg.viz_gradient ? get_gradient_color((float)v / (float)max_h) : cfg.fg_rgb;
             else color = unlit_color;
@@ -430,19 +437,17 @@ static void draw_bars_mode(int band_count) {
             int peak_h = (int)(viz_peaks[i] * max_h);
             if (peak_h >= max_h) peak_h = max_h - 1;
             uint16_t peak_color = cfg.viz_gradient ? 0xF800 : cfg.fg_rgb;
-            for (int w = 0; w < draw_bar_width; w++) {
-                draw_pixel(x_base + w, base_y - peak_h, peak_color);
-                if (peak_h + 1 < max_h) draw_pixel(x_base + w, base_y - peak_h - 1, peak_color);
+            for (int v = 0; v < 2 * s && peak_h + v < max_h; v++) {
+                for (int w = 0; w < draw_bar_width; w++)
+                    draw_pixel(x_base + w, base_y - peak_h - v, peak_color);
             }
         }
     }
 }
 
 static void draw_dot(int x, int y, uint16_t color) {
-    draw_pixel(x, y, color);
-    draw_pixel(x + 1, y, color);
-    draw_pixel(x, y - 1, color);
-    draw_pixel(x + 1, y - 1, color);
+    int s = viz_s();
+    draw_rect_fill(x, y - (2 * s - 1), 2 * s, 2 * s, color);
 }
 
 static void draw_dots_mode(int band_count) {
@@ -463,7 +468,7 @@ static void draw_dots_mode(int band_count) {
     for (int i = 0; i < band_count; i++) {
         int h = (int)(viz_levels[i] * max_h);
         if (h >= max_h) h = max_h - 1;
-        int x = viz_band_x(i, band_count, 2);
+        int x = viz_band_x(i, band_count, 2 * viz_s());
         uint16_t color = cfg.viz_gradient ? get_gradient_color(viz_levels[i]) : cfg.fg_rgb;
 
         // Phosphor trail: older ghost first, both dimmed toward the bg.
@@ -490,8 +495,7 @@ static void draw_dots_mode(int band_count) {
             int peak_h = (int)(viz_peaks[i] * max_h);
             if (peak_h >= max_h) peak_h = max_h - 1;
             uint16_t peak_color = cfg.viz_gradient ? 0xF800 : cfg.fg_rgb;
-            draw_pixel(x, base_y - peak_h, peak_color);
-            draw_pixel(x + 1, base_y - peak_h, peak_color);
+            draw_rect_fill(x, base_y - peak_h, 2 * viz_s(), viz_s(), peak_color);
         }
     }
 }
@@ -537,8 +541,7 @@ static void draw_line_mode(int band_count) {
             int peak_h = (int)(viz_peaks[i] * max_h);
             if (peak_h >= max_h) peak_h = max_h - 1;
             uint16_t peak_color = cfg.viz_gradient ? 0xF800 : cfg.fg_rgb;
-            draw_pixel(x, base_y - peak_h, peak_color);
-            draw_pixel(x + 1, base_y - peak_h, peak_color);
+            draw_rect_fill(x, base_y - peak_h, 2 * viz_s(), viz_s(), peak_color);
         }
     }
 }
@@ -546,6 +549,7 @@ static void draw_line_mode(int band_count) {
 // Meter face for the -40..0 dB sweep: unlit track, ticks at -30/-20/-10/-6,
 // red zone above -6 dB.
 static void vu_draw_face(int meter_x, int row_y, int meter_w, int meter_h) {
+    int s = viz_s();
     uint16_t track_color = mix565(cfg.bg_rgb, cfg.fg_rgb, 30);
     uint16_t tick_color = mix565(cfg.bg_rgb, cfg.fg_rgb, 100);
     uint16_t zone_color = mix565(cfg.bg_rgb, 0xF800, 100);
@@ -556,13 +560,14 @@ static void vu_draw_face(int meter_x, int row_y, int meter_w, int meter_h) {
     draw_rect_fill(meter_x + zone_x, row_y, meter_w - zone_x, meter_h, zone_color);
     for (int t = 0; t < 4; t++) {
         int tx = meter_x + (int)((float)meter_w * tick_pos[t]);
-        for (int y = -1; y <= meter_h; y++) draw_pixel(tx, row_y + y, tick_color);
+        draw_rect_fill(tx, row_y - s, s, meter_h + 2 * s, tick_color);
     }
 }
 
 static void vu_draw_meter_row(int label_x, int meter_x, int row_y, int meter_w,
                               int meter_h, int channel, const char *label) {
-    draw_text(label_x, row_y, label, cfg.fg_rgb);
+    int s = viz_s();
+    draw_text_scaled_clipped(label_x, row_y, label, cfg.fg_rgb, s, 0, fb_width);
     vu_draw_face(meter_x, row_y, meter_w, meter_h);
 
     int fill_w = (int)(viz_levels[channel] * meter_w);
@@ -576,14 +581,15 @@ static void vu_draw_meter_row(int label_x, int meter_x, int row_y, int meter_w,
         uint16_t peak_color = cfg.viz_gradient ? 0xF800 : cfg.fg_rgb;
         int peak_x = (int)(viz_peaks[channel] * meter_w);
         if (peak_x >= meter_w) peak_x = meter_w - 1;
-        for (int y = 0; y < meter_h; y++) draw_pixel(meter_x + peak_x, row_y + y, peak_color);
+        draw_rect_fill(meter_x + peak_x, row_y, s, meter_h, peak_color);
     }
 }
 
 static void draw_vu_meter_mode(void) {
-    const int meter_h = 4;
-    const int meter_gap = 4;
-    const int label_h = 8;
+    const int s = viz_s();
+    const int meter_h = 4 * s;
+    const int meter_gap = 4 * s;
+    const int label_h = 8 * s;
     const int row_step = (meter_h + meter_gap > label_h) ? (meter_h + meter_gap) : label_h;
     const int pair_h = row_step + label_h;
 
@@ -610,7 +616,7 @@ static int16_t scope_at(int idx) {
 static void draw_scope_mode(void) {
     int x0 = layout.viz_inner.x;
     int w = layout.viz_inner.w;
-    if (w > FB_WIDTH) w = FB_WIDTH;
+    if (w > FB_MAX_WIDTH) w = FB_MAX_WIDTH;
     int half = (layout.viz_inner.h - 2) / 2;
     if (half < 1) half = 1;
     int cy = layout.viz_inner.y + layout.viz_inner.h / 2;
@@ -623,7 +629,7 @@ static void draw_scope_mode(void) {
 
     // Graticule: center hairline plus dot ticks along the top and bottom rails.
     for (int x = 0; x < w; x++) draw_pixel(x0 + x, cy, grid);
-    for (int x = 0; x < w; x += 10) {
+    for (int x = 0; x < w; x += 10 * viz_s()) {
         draw_pixel(x0 + x, cy - half, grid);
         draw_pixel(x0 + x, cy + half, grid);
     }
@@ -691,6 +697,7 @@ static void draw_scope_mode(void) {
 // Kenwood-style mirrored spectrum: bands fan out from a center emblem with an
 // outward shear, LED-segmented, over a horizon line with a dimmed reflection.
 static void draw_mirror_mode(int band_count) {
+    const int s = viz_s();
     Rect in = layout.viz_inner;
     int cx = in.x + in.w / 2;
 
@@ -709,9 +716,9 @@ static void draw_mirror_mode(int band_count) {
     if (max_h < 1) max_h = 1;
     int max_shear = max_h / 6;
 
-    int emblem_w = 30;
+    int emblem_w = 30 * s;
     if (emblem_w > in.w / 3) emblem_w = in.w / 3;
-    int half_avail = (in.w - emblem_w) / 2 - 2 - max_shear;
+    int half_avail = (in.w - emblem_w) / 2 - 2 * s - max_shear;
     if (half_avail < 1) half_avail = 1;
     // Narrow panels decimate evenly across the spectrum instead of silently
     // truncating the treble bands away.
@@ -720,7 +727,7 @@ static void draw_mirror_mode(int band_count) {
     if (spacing < 1) spacing = 1;
     int bar_w = spacing - 1;
     if (bar_w < 1) bar_w = 1;
-    if (bar_w > 4) bar_w = 4;
+    if (bar_w > 4 * s) bar_w = 4 * s;
 
     for (int x = 0; x < in.w; x++) draw_pixel(in.x + x, base_y, horizon);
 
@@ -728,7 +735,7 @@ static void draw_mirror_mode(int band_count) {
         int src = i * band_count / draw_bands;
         int h = (int)(viz_levels[src] * max_h);
         if (h > max_h) h = max_h;
-        int off0 = emblem_w / 2 + 2 + i * spacing;
+        int off0 = emblem_w / 2 + 2 * s + i * spacing;
 
         for (int side = 0; side < 2; side++) {
             int dir = side ? -1 : 1;
@@ -770,10 +777,10 @@ static void draw_mirror_mode(int band_count) {
     // Center emblem: a bass-pulsing diamond crest — a dim outline ring with a
     // solid core that grows and heats up with the low bands.
     float bass = (viz_levels[0] + viz_levels[1] + viz_levels[2]) / 3.0f;
-    int es = 18 + (int)(bass * 8.0f);
-    if (es > emblem_w - 2) es = emblem_w - 2;
-    if (es > up_h - 2) es = up_h - 2;
-    if (es >= 6) {
+    int es = (18 + (int)(bass * 8.0f)) * s;
+    if (es > emblem_w - 2 * s) es = emblem_w - 2 * s;
+    if (es > up_h - 2 * s) es = up_h - 2 * s;
+    if (es >= 6 * s) {
         int r = es / 2;
         int my = in.y + (up_h - es) / 2 + r;
         uint16_t ring = mix565(panel, cfg.fg_rgb, 80);
@@ -781,10 +788,10 @@ static void draw_mirror_mode(int band_count) {
 
         for (int dy = -r; dy <= r; dy++) {
             int wl = r - ((dy < 0) ? -dy : dy);
-            draw_pixel(cx - wl, my + dy, ring);
-            draw_pixel(cx + wl, my + dy, ring);
+            draw_rect_fill(cx - wl, my + dy, s, 1, ring);
+            draw_rect_fill(cx + wl - s + 1, my + dy, s, 1, ring);
         }
-        int rc = r - 3;
+        int rc = r - 3 * s;
         if (rc < 1) rc = 1;
         for (int dy = -rc; dy <= rc; dy++) {
             int wl = rc - ((dy < 0) ? -dy : dy);

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -34,12 +34,12 @@ static int viz_band_x(int band_idx, int band_count, int item_w, int start_x, int
     if (!cfg.responsive) return start_x + (band_idx * spacing);
 
     if (item_w < 1) item_w = 1;
-    if (item_w > layout.viz.w) item_w = layout.viz.w;
-    if (layout.viz.w <= item_w) return layout.viz.x;
-    if (band_count <= 1) return layout.viz.x + (layout.viz.w - item_w) / 2;
+    if (item_w > layout.viz_inner.w) item_w = layout.viz_inner.w;
+    if (layout.viz_inner.w <= item_w) return layout.viz_inner.x;
+    if (band_count <= 1) return layout.viz_inner.x + (layout.viz_inner.w - item_w) / 2;
 
-    int span = layout.viz.w - item_w;
-    return layout.viz.x + (band_idx * span) / (band_count - 1);
+    int span = layout.viz_inner.w - item_w;
+    return layout.viz_inner.x + (band_idx * span) / (band_count - 1);
 }
 
 uint16_t get_gradient_color(float level) {
@@ -349,7 +349,7 @@ static void draw_bars_mode(int band_count) {
         bar_width = layout.viz_bar_width;
         spacing = layout.viz_spacing;
         max_h = layout.viz_max_h;
-        base_y = layout.viz.y + layout.viz.h - 1;
+        base_y = layout.viz_inner.y + layout.viz_inner.h - 1;
     } else {
         start_x = (band_count == 40) ? 80 : 100;
         bar_width = (band_count == 40) ? 2 : 4;
@@ -360,7 +360,7 @@ static void draw_bars_mode(int band_count) {
     if (max_h < 1) max_h = 1;
 
     int draw_bar_width = bar_width;
-    if (cfg.responsive && draw_bar_width > layout.viz.w) draw_bar_width = layout.viz.w;
+    if (cfg.responsive && draw_bar_width > layout.viz_inner.w) draw_bar_width = layout.viz_inner.w;
 
     for (int i = 0; i < band_count; i++) {
         int h = (int)(viz_levels[i] * max_h);
@@ -395,20 +395,20 @@ static void draw_dots_mode(int band_count) {
     if (cfg.responsive) {
         spacing = layout.viz_spacing;
         max_h = layout.viz_max_h;
-        base_y = layout.viz.y + layout.viz.h - 1;
+        base_y = layout.viz_inner.y + layout.viz_inner.h - 1;
         if (spacing < 2) spacing = 2;
 
         // Keep 2x2 dots inside the responsive visualizer bounds.
         if (band_count > 1) {
             int dots_w = spacing * (band_count - 1) + 2;
-            if (dots_w > layout.viz.w) {
-                spacing = (layout.viz.w - 2) / (band_count - 1);
+            if (dots_w > layout.viz_inner.w) {
+                spacing = (layout.viz_inner.w - 2) / (band_count - 1);
                 if (spacing < 1) spacing = 1;
                 dots_w = spacing * (band_count - 1) + 2;
             }
-            start_x = layout.viz.x + (layout.viz.w - dots_w) / 2;
+            start_x = layout.viz_inner.x + (layout.viz_inner.w - dots_w) / 2;
         } else {
-            start_x = layout.viz.x + (layout.viz.w - 2) / 2;
+            start_x = layout.viz_inner.x + (layout.viz_inner.w - 2) / 2;
         }
     } else {
         start_x = (band_count == 40) ? 100 : 130;
@@ -451,7 +451,7 @@ static void draw_line_mode(int band_count) {
         start_x = layout.viz_start_x;
         spacing = layout.viz_spacing;
         max_h = layout.viz_max_h;
-        base_y = layout.viz.y + layout.viz.h - 1;
+        base_y = layout.viz_inner.y + layout.viz_inner.h - 1;
     } else {
         start_x = (band_count == 40) ? 80 : 100;
         spacing = (band_count == 40) ? 4 : 6;
@@ -509,17 +509,17 @@ static void draw_vu_meter_mode(void) {
     if (cfg.responsive) {
         meter_w = layout.viz_meter_w;
         if (meter_w < 1) meter_w = 1;
-        meter_x = layout.viz.x + (layout.viz.w - meter_w);
-        label_x = layout.viz.x;
+        meter_x = layout.viz_inner.x + (layout.viz_inner.w - meter_w);
+        label_x = layout.viz_inner.x;
 
-        if (layout.viz.h >= pair_h) {
-            int pair_top = layout.viz.y + (layout.viz.h - pair_h) / 2;
+        if (layout.viz_inner.h >= pair_h) {
+            int pair_top = layout.viz_inner.y + (layout.viz_inner.h - pair_h) / 2;
             left_y = pair_top;
             right_y = pair_top + row_step;
         } else {
             // Too short for two meters, show only left as a mono meter
-            left_y = layout.viz.y + (layout.viz.h - meter_h) / 2;
-            if (left_y < layout.viz.y) left_y = layout.viz.y;
+            left_y = layout.viz_inner.y + (layout.viz_inner.h - meter_h) / 2;
+            if (left_y < layout.viz_inner.y) left_y = layout.viz_inner.y;
             right_y = -1;
         }
     }
@@ -574,7 +574,7 @@ void viz_reset_state(void) {
 
 void viz_draw(void) {
     int band_count = cfg.viz_bands;
-    if (cfg.responsive && (layout.viz.w <= 0 || layout.viz.h <= 0)) return;
+    if (cfg.responsive && (layout.viz_inner.w <= 0 || layout.viz_inner.h <= 0)) return;
 
     if (cfg.viz_mode == VIZ_MODE_BARS || cfg.viz_mode == VIZ_MODE_FFT_EQ_LEGACY) {
         draw_bars_mode(band_count);

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -15,6 +15,16 @@ int viz_peak_timers[MAX_VIZ_BANDS] = {0};
 static int dot_trail[MAX_VIZ_BANDS][2] = {{0}};
 static int dot_trail_tick = 0;
 
+// Scope mode: raw mono sample ring plus per-column afterglow traces.
+#define SCOPE_RING 2048
+#define SCOPE_SPAN 800            // ~17ms window at 48kHz
+#define SCOPE_TRIGGER_SEARCH 480  // rising-zero-crossing hunt range
+static int16_t scope_ring[SCOPE_RING] = {0};
+static int scope_ring_pos = 0;
+static int16_t scope_ghost_lo[2][FB_WIDTH] = {{0}};
+static int16_t scope_ghost_hi[2][FB_WIDTH] = {{0}};
+static int scope_ghost_tick = 0;
+
 // 2048 points at 48kHz gives ~23Hz bins so the low log-spaced bands stop
 // sharing bins; the analysis window grows to ~43ms, fine for a visualizer.
 #define FFT_SIZE 2048
@@ -327,13 +337,29 @@ static void vu_update_levels(const int16_t *audio_buf, int samples_per_frame, in
     }
 }
 
+// Always fed so switching into Scope mode shows a live trace immediately.
+static void scope_feed(const int16_t *audio_buf, int samples_per_frame) {
+    if (!audio_buf || samples_per_frame <= 0) return;
+    for (int i = 0; i < samples_per_frame; i++) {
+        int32_t mono = ((int32_t)audio_buf[i * 2] + (int32_t)audio_buf[i * 2 + 1]) / 2;
+        scope_ring[scope_ring_pos] = (int16_t)mono;
+        scope_ring_pos = (scope_ring_pos + 1) & (SCOPE_RING - 1);
+    }
+}
+
 void viz_update_levels(const int16_t *audio_buf, int samples_per_frame) {
     int band_count = cfg.viz_bands;
     if (band_count < 1) band_count = 1;
     if (band_count > MAX_VIZ_BANDS) band_count = MAX_VIZ_BANDS;
 
+    scope_feed(audio_buf, samples_per_frame);
+
     if (cfg.viz_mode == VIZ_MODE_VU) {
         vu_update_levels(audio_buf, samples_per_frame, band_count);
+        return;
+    }
+    if (cfg.viz_mode == VIZ_MODE_SCOPE) {
+        viz_decay_levels(band_count);
         return;
     }
 
@@ -533,12 +559,100 @@ static void draw_vu_meter_mode(void) {
     vu_draw_meter_row(label_x, meter_x, pair_top + row_step, meter_w, meter_h, 1, "R");
 }
 
+static int16_t scope_at(int idx) {
+    return scope_ring[idx & (SCOPE_RING - 1)];
+}
+
+// Triggered oscilloscope with a car-deck face: dot graticule, per-column
+// min/max envelope, amplitude-gradient trace with a glow edge, and two
+// afterglow ghost traces.
+static void draw_scope_mode(void) {
+    int x0 = layout.viz_inner.x;
+    int w = layout.viz_inner.w;
+    if (w > FB_WIDTH) w = FB_WIDTH;
+    int half = (layout.viz_inner.h - 2) / 2;
+    if (half < 1) half = 1;
+    int cy = layout.viz_inner.y + layout.viz_inner.h / 2;
+
+    uint16_t panel = mix565(cfg.bg_rgb, 0x0000, 150);
+    uint16_t grid = mix565(panel, cfg.fg_rgb, 26);
+    uint16_t glow = mix565(panel, cfg.fg_rgb, 70);
+    uint16_t ghost0 = mix565(cfg.fg_rgb, panel, 150);
+    uint16_t ghost1 = mix565(cfg.fg_rgb, panel, 200);
+
+    // Graticule: center hairline plus dot ticks along the top and bottom rails.
+    for (int x = 0; x < w; x++) draw_pixel(x0 + x, cy, grid);
+    for (int x = 0; x < w; x += 10) {
+        draw_pixel(x0 + x, cy - half, grid);
+        draw_pixel(x0 + x, cy + half, grid);
+    }
+
+    // Trigger: align the window to the first rising zero crossing so the
+    // trace holds still instead of jittering.
+    int idx0 = scope_ring_pos + SCOPE_RING - SCOPE_SPAN - SCOPE_TRIGGER_SEARCH;
+    int win = idx0;
+    for (int k = 0; k < SCOPE_TRIGGER_SEARCH - 1; k++) {
+        if (scope_at(idx0 + k) < 0 && scope_at(idx0 + k + 1) >= 0) {
+            win = idx0 + k + 1;
+            break;
+        }
+    }
+
+    // Afterglow ghosts, oldest first, then the live trace over them.
+    for (int g = 1; g >= 0; g--) {
+        uint16_t gc = (g == 0) ? ghost0 : ghost1;
+        for (int x = 0; x < w; x++) {
+            int lo = scope_ghost_lo[g][x], hi = scope_ghost_hi[g][x];
+            if (lo < -half) lo = -half;
+            if (hi > half) hi = half;
+            for (int yy = lo; yy <= hi; yy++) draw_pixel(x0 + x, cy - yy, gc);
+        }
+    }
+
+    scope_ghost_tick ^= 1;
+    int record = (scope_ghost_tick == 0);
+
+    for (int x = 0; x < w; x++) {
+        int s0 = win + (x * SCOPE_SPAN) / w;
+        int s1 = win + ((x + 1) * SCOPE_SPAN) / w;
+        if (s1 <= s0) s1 = s0 + 1;
+        int mn = 32767, mx = -32768;
+        for (int s = s0; s < s1; s++) {
+            int v = scope_at(s);
+            if (v < mn) mn = v;
+            if (v > mx) mx = v;
+        }
+        int ylo = (mn * half) / 32768;
+        int yhi = (mx * half) / 32768;
+
+        for (int yy = ylo; yy <= yhi; yy++) {
+            int dist = (yy < 0) ? -yy : yy;
+            uint16_t c = cfg.viz_gradient ? get_gradient_color((float)dist / (float)half) : cfg.fg_rgb;
+            draw_pixel(x0 + x, cy - yy, c);
+        }
+        if (yhi + 1 <= half) draw_pixel(x0 + x, cy - (yhi + 1), glow);
+        if (ylo - 1 >= -half) draw_pixel(x0 + x, cy - (ylo - 1), glow);
+
+        if (record) {
+            scope_ghost_lo[1][x] = scope_ghost_lo[0][x];
+            scope_ghost_hi[1][x] = scope_ghost_hi[0][x];
+            scope_ghost_lo[0][x] = (int16_t)ylo;
+            scope_ghost_hi[0][x] = (int16_t)yhi;
+        }
+    }
+}
+
 void viz_reset_state(void) {
     memset(viz_levels, 0, sizeof(viz_levels));
     memset(viz_peaks, 0, sizeof(viz_peaks));
     memset(viz_peak_timers, 0, sizeof(viz_peak_timers));
     memset(dot_trail, 0, sizeof(dot_trail));
     dot_trail_tick = 0;
+    memset(scope_ring, 0, sizeof(scope_ring));
+    scope_ring_pos = 0;
+    memset(scope_ghost_lo, 0, sizeof(scope_ghost_lo));
+    memset(scope_ghost_hi, 0, sizeof(scope_ghost_hi));
+    scope_ghost_tick = 0;
     memset(fft_re, 0, sizeof(fft_re));
     memset(fft_im, 0, sizeof(fft_im));
     memset(fft_band_energy, 0, sizeof(fft_band_energy));
@@ -564,5 +678,7 @@ void viz_draw(void) {
         draw_line_mode(band_count);
     } else if (cfg.viz_mode == VIZ_MODE_VU) {
         draw_vu_meter_mode();
+    } else if (cfg.viz_mode == VIZ_MODE_SCOPE) {
+        draw_scope_mode();
     }
 }

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -279,40 +279,39 @@ static void fft_update_levels(const int16_t *audio_buf, int samples_per_frame, i
     }
 }
 
+// Map channel RMS onto the meter's -40..0 dB sweep.
+static float vu_db_level(float rms) {
+    if (rms <= 0.0001f) return 0.0f;
+    float db = 20.0f * log10f(rms);
+    float v = (db + 40.0f) / 40.0f;
+    if (v < 0.0f) v = 0.0f;
+    if (v > 1.0f) v = 1.0f;
+    return v;
+}
+
 static void vu_update_levels(const int16_t *audio_buf, int samples_per_frame, int band_count) {
-    float left_level = 0.0f, right_level = 0.0f;
-    float left_sum = 0.0f, right_sum = 0.0f;
-    float left_peak = 0.0f, right_peak = 0.0f;
+    float left_sq = 0.0f, right_sq = 0.0f;
     int level_samples = 0;
 
     if (audio_buf && samples_per_frame > 0) {
         for (int i = 0; i < samples_per_frame; i += 4) {
-            int32_t ls = audio_buf[i * 2], rs = audio_buf[i * 2 + 1];
-            float l = (ls < 0 ? -ls : ls) / 32768.0f;
-            float r = (rs < 0 ? -rs : rs) / 32768.0f;
-            left_sum += l;
-            right_sum += r;
-            if (l > left_peak) left_peak = l;
-            if (r > right_peak) right_peak = r;
+            float l = (float)audio_buf[i * 2] / 32768.0f;
+            float r = (float)audio_buf[i * 2 + 1] / 32768.0f;
+            left_sq += l * l;
+            right_sq += r * r;
             level_samples++;
         }
     }
 
+    float left_target = 0.0f, right_target = 0.0f;
     if (level_samples > 0) {
-        float left_avg = left_sum / (float)level_samples;
-        float right_avg = right_sum / (float)level_samples;
-
-        // Blend average + peak so channels stay responsive but don't collapse to identical values.
-        left_level = left_avg * 0.75f + left_peak * 0.25f;
-        right_level = right_avg * 0.75f + right_peak * 0.25f;
-        if (left_level > 1.0f) left_level = 1.0f;
-        if (right_level > 1.0f) right_level = 1.0f;
+        left_target = vu_db_level(sqrtf(left_sq / (float)level_samples));
+        right_target = vu_db_level(sqrtf(right_sq / (float)level_samples));
     }
 
-    if (left_level > viz_levels[0]) viz_levels[0] = left_level;
-    else viz_levels[0] *= 0.85f;
-    if (right_level > viz_levels[1]) viz_levels[1] = right_level;
-    else viz_levels[1] *= 0.85f;
+    // ~150ms integration in both directions for the analog needle feel.
+    viz_levels[0] = viz_levels[0] * 0.88f + left_target * 0.12f;
+    viz_levels[1] = viz_levels[1] * 0.88f + right_target * 0.12f;
 
     viz_update_peak(0);
     viz_update_peak(1);
@@ -443,6 +442,43 @@ static void draw_line_mode(int band_count) {
     }
 }
 
+// Meter face for the -40..0 dB sweep: unlit track, ticks at -30/-20/-10/-6,
+// red zone above -6 dB.
+static void vu_draw_face(int meter_x, int row_y, int meter_w, int meter_h) {
+    uint16_t track_color = mix565(cfg.bg_rgb, cfg.fg_rgb, 30);
+    uint16_t tick_color = mix565(cfg.bg_rgb, cfg.fg_rgb, 100);
+    uint16_t zone_color = mix565(cfg.bg_rgb, 0xF800, 100);
+    static const float tick_pos[4] = {0.25f, 0.50f, 0.75f, 0.85f};
+
+    draw_rect_fill(meter_x, row_y, meter_w, meter_h, track_color);
+    int zone_x = (int)((float)meter_w * 0.85f);
+    draw_rect_fill(meter_x + zone_x, row_y, meter_w - zone_x, meter_h, zone_color);
+    for (int t = 0; t < 4; t++) {
+        int tx = meter_x + (int)((float)meter_w * tick_pos[t]);
+        for (int y = -1; y <= meter_h; y++) draw_pixel(tx, row_y + y, tick_color);
+    }
+}
+
+static void vu_draw_meter_row(int label_x, int meter_x, int row_y, int meter_w,
+                              int meter_h, int channel, const char *label) {
+    draw_text(label_x, row_y, label, cfg.fg_rgb);
+    vu_draw_face(meter_x, row_y, meter_w, meter_h);
+
+    int fill_w = (int)(viz_levels[channel] * meter_w);
+    if (fill_w > meter_w) fill_w = meter_w;
+    for (int x = 0; x < fill_w; x++) {
+        uint16_t color = cfg.viz_gradient ? get_gradient_color((float)x / (float)meter_w) : cfg.fg_rgb;
+        for (int y = 0; y < meter_h; y++) draw_pixel(meter_x + x, row_y + y, color);
+    }
+
+    if (cfg.viz_peak_hold > 0 && viz_peak_timers[channel] > 0) {
+        uint16_t peak_color = cfg.viz_gradient ? 0xF800 : cfg.fg_rgb;
+        int peak_x = (int)(viz_peaks[channel] * meter_w);
+        if (peak_x >= meter_w) peak_x = meter_w - 1;
+        for (int y = 0; y < meter_h; y++) draw_pixel(meter_x + peak_x, row_y + y, peak_color);
+    }
+}
+
 static void draw_vu_meter_mode(void) {
     const int meter_h = 4;
     const int meter_gap = 4;
@@ -450,54 +486,17 @@ static void draw_vu_meter_mode(void) {
     const int row_step = (meter_h + meter_gap > label_h) ? (meter_h + meter_gap) : label_h;
     const int pair_h = row_step + label_h;
 
+    // Two meters or nothing — a lone mono meter reads as a broken channel.
+    if (layout.viz_inner.h < pair_h) return;
+
     int meter_w = layout.viz_meter_w;
     if (meter_w < 1) meter_w = 1;
     int meter_x = layout.viz_inner.x + (layout.viz_inner.w - meter_w);
     int label_x = layout.viz_inner.x;
-    int left_y;
-    int right_y;
+    int pair_top = layout.viz_inner.y + (layout.viz_inner.h - pair_h) / 2;
 
-    if (layout.viz_inner.h >= pair_h) {
-        int pair_top = layout.viz_inner.y + (layout.viz_inner.h - pair_h) / 2;
-        left_y = pair_top;
-        right_y = pair_top + row_step;
-    } else {
-        // Too short for two meters, show only left as a mono meter
-        left_y = layout.viz_inner.y + (layout.viz_inner.h - meter_h) / 2;
-        if (left_y < layout.viz_inner.y) left_y = layout.viz_inner.y;
-        right_y = -1;
-    }
-
-    // Draw Left meter
-    draw_text(label_x, left_y, "L", cfg.fg_rgb);
-    int left_w = (int)(viz_levels[0] * meter_w);
-    if (left_w > meter_w) left_w = meter_w;
-    for (int x = 0; x < left_w; x++) {
-        uint16_t color = cfg.viz_gradient ? get_gradient_color((float)x / (float)meter_w) : cfg.fg_rgb;
-        for (int y = 0; y < meter_h; y++) draw_pixel(meter_x + x, left_y + y, color);
-    }
-    uint16_t peak_color = cfg.viz_gradient ? 0xF800 : cfg.fg_rgb;
-    if (cfg.viz_peak_hold > 0 && viz_peak_timers[0] > 0) {
-        int peak_x = (int)(viz_peaks[0] * meter_w);
-        if (peak_x >= meter_w) peak_x = meter_w - 1;
-        for (int y = 0; y < meter_h; y++) draw_pixel(meter_x + peak_x, left_y + y, peak_color);
-    }
-
-    // Draw Right meter (skip if too short for two meters)
-    if (right_y >= 0) {
-        draw_text(label_x, right_y, "R", cfg.fg_rgb);
-        int right_w = (int)(viz_levels[1] * meter_w);
-        if (right_w > meter_w) right_w = meter_w;
-        for (int x = 0; x < right_w; x++) {
-            uint16_t color = cfg.viz_gradient ? get_gradient_color((float)x / (float)meter_w) : cfg.fg_rgb;
-            for (int y = 0; y < meter_h; y++) draw_pixel(meter_x + x, right_y + y, color);
-        }
-        if (cfg.viz_peak_hold > 0 && viz_peak_timers[1] > 0) {
-            int peak_x = (int)(viz_peaks[1] * meter_w);
-            if (peak_x >= meter_w) peak_x = meter_w - 1;
-            for (int y = 0; y < meter_h; y++) draw_pixel(meter_x + peak_x, right_y + y, peak_color);
-        }
-    }
+    vu_draw_meter_row(label_x, meter_x, pair_top, meter_w, meter_h, 0, "L");
+    vu_draw_meter_row(label_x, meter_x, pair_top + row_step, meter_w, meter_h, 1, "R");
 }
 
 void viz_reset_state(void) {

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -11,6 +11,10 @@ float viz_levels[MAX_VIZ_BANDS] = {0};
 float viz_peaks[MAX_VIZ_BANDS] = {0};
 int viz_peak_timers[MAX_VIZ_BANDS] = {0};
 
+// Dots-mode phosphor trail: previous dot heights, most recent first.
+static int dot_trail[MAX_VIZ_BANDS][2] = {{0}};
+static int dot_trail_tick = 0;
+
 // 2048 points at 48kHz gives ~23Hz bins so the low log-spaced bands stop
 // sharing bins; the analysis window grows to ~43ms, fine for a visualizer.
 #define FFT_SIZE 2048
@@ -375,10 +379,21 @@ static void draw_bars_mode(int band_count) {
     }
 }
 
+static void draw_dot(int x, int y, uint16_t color) {
+    draw_pixel(x, y, color);
+    draw_pixel(x + 1, y, color);
+    draw_pixel(x, y - 1, color);
+    draw_pixel(x + 1, y - 1, color);
+}
+
 static void draw_dots_mode(int band_count) {
     int max_h = layout.viz_max_h;
     int base_y = layout.viz_inner.y + layout.viz_inner.h - 1;
     if (max_h < 1) max_h = 1;
+
+    // Record ghost positions every other frame so the trail visibly lags.
+    dot_trail_tick ^= 1;
+    int record = (dot_trail_tick == 0);
 
     for (int i = 0; i < band_count; i++) {
         int h = (int)(viz_levels[i] * max_h);
@@ -386,11 +401,20 @@ static void draw_dots_mode(int band_count) {
         int x = viz_band_x(i, band_count, 2);
         uint16_t color = cfg.viz_gradient ? get_gradient_color(viz_levels[i]) : cfg.fg_rgb;
 
-        // Draw 2x2 dot
-        draw_pixel(x, base_y - h, color);
-        draw_pixel(x + 1, base_y - h, color);
-        draw_pixel(x, base_y - h - 1, color);
-        draw_pixel(x + 1, base_y - h - 1, color);
+        // Phosphor trail: older ghost first, both dimmed toward the bg.
+        for (int g = 1; g >= 0; g--) {
+            int gh = dot_trail[i][g];
+            uint16_t gcolor = cfg.viz_gradient ? get_gradient_color((float)gh / (float)max_h) : cfg.fg_rgb;
+            gcolor = mix565(gcolor, cfg.bg_rgb, (g == 0) ? 140 : 195);
+            draw_dot(x, base_y - gh, gcolor);
+        }
+
+        if (record) {
+            dot_trail[i][1] = dot_trail[i][0];
+            dot_trail[i][0] = h;
+        }
+
+        draw_dot(x, base_y - h, color);
 
         // Peak dot
         if (cfg.viz_peak_hold > 0 && viz_peak_timers[i] > 0) {
@@ -511,6 +535,8 @@ void viz_reset_state(void) {
     memset(viz_levels, 0, sizeof(viz_levels));
     memset(viz_peaks, 0, sizeof(viz_peaks));
     memset(viz_peak_timers, 0, sizeof(viz_peak_timers));
+    memset(dot_trail, 0, sizeof(dot_trail));
+    dot_trail_tick = 0;
     memset(fft_re, 0, sizeof(fft_re));
     memset(fft_im, 0, sizeof(fft_im));
     memset(fft_band_energy, 0, sizeof(fft_band_energy));

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -349,7 +349,9 @@ static void draw_bars_mode(int band_count) {
     if (draw_bar_width > layout.viz_inner.w) draw_bar_width = layout.viz_inner.w;
     if (draw_bar_width < 1) draw_bar_width = 1;
 
-    uint16_t unlit_color = mix565(cfg.bg_rgb, cfg.fg_rgb, 28);
+    // Unlit segments sit just above the sunken panel shade (ui_palette mixes
+    // the panel at bg->black 150), not the brighter screen background.
+    uint16_t unlit_color = mix565(mix565(cfg.bg_rgb, 0x0000, 150), cfg.fg_rgb, 16);
 
     for (int i = 0; i < band_count; i++) {
         int h = (int)(viz_levels[i] * max_h);

--- a/src/visualizer.c
+++ b/src/visualizer.c
@@ -20,8 +20,11 @@ void viz_set_frame_dt(float dt) {
     viz_dt = dt;
 }
 
-// Resolution scale (1x = 320x240, 2x = 640x480): pixel-sized details are
-// authored at 1x and multiplied so the modes read identically when scaled.
+// Resolution scale (1x-4x multiples of 320x240): chunky elements (LED
+// segments, dots, meters, peak markers) are authored at 1x and multiplied so
+// they read identically when scaled. Hairline traces — the Line connector,
+// the Scope trace, and graticule dots — deliberately stay one pixel: getting
+// finer with resolution is the point of those elements.
 static int viz_s(void) {
     return (cfg.ui_scale > 0) ? cfg.ui_scale : 1;
 }
@@ -682,8 +685,10 @@ static void draw_scope_mode(void) {
             uint16_t c = cfg.viz_gradient ? get_gradient_color((float)dist / (float)half) : cfg.fg_rgb;
             draw_pixel(x0 + x, cy - yy, c);
         }
-        if (yhi + 1 <= half) draw_pixel(x0 + x, cy - (yhi + 1), glow);
-        if (ylo - 1 >= -half) draw_pixel(x0 + x, cy - (ylo - 1), glow);
+        for (int g = 1; g <= viz_s(); g++) {
+            if (yhi + g <= half) draw_pixel(x0 + x, cy - (yhi + g), glow);
+            if (ylo - g >= -half) draw_pixel(x0 + x, cy - (ylo - g), glow);
+        }
 
         if (record) {
             scope_ghost_lo[1][x] = scope_ghost_lo[0][x];
@@ -742,7 +747,7 @@ static void draw_mirror_mode(int band_count) {
 
             // LED ladder leaning outward: shear grows with height.
             for (int v = 0; v < max_h; v++) {
-                if ((v % 3) == 2) continue;
+                if (((v / s) % 3) == 2) continue;
                 int bx = cx + dir * (off0 + v / 6);
                 uint16_t color = (v < h)
                     ? (cfg.viz_gradient ? get_gradient_color((float)v / (float)max_h) : cfg.fg_rgb)
@@ -755,7 +760,7 @@ static void draw_mirror_mode(int band_count) {
             int rh = h / 2;
             if (rh > refl_h) rh = refl_h;
             for (int v = 0; v < rh; v++) {
-                if ((v % 3) == 2) continue;
+                if (((v / s) % 3) == 2) continue;
                 int bx = cx + dir * (off0 + (v * 2) / 6);
                 uint16_t src = cfg.viz_gradient ? get_gradient_color((float)(v * 2) / (float)max_h) : cfg.fg_rgb;
                 uint16_t color = mix565(src, panel, 150);

--- a/src/visualizer.h
+++ b/src/visualizer.h
@@ -12,6 +12,9 @@ extern int viz_peak_timers[MAX_VIZ_BANDS];
 // Update visualizer levels from audio buffer
 void viz_update_levels(const int16_t *audio_buf, int samples_per_frame);
 
+// Report the frontend's frame duration so cadences advance in real time
+void viz_set_frame_dt(float dt);
+
 // Draw current visualizer mode
 void viz_draw(void);
 

--- a/tests/core_harness.c
+++ b/tests/core_harness.c
@@ -1132,6 +1132,8 @@ static bool test_track_change_resets_fft_visualizer_state(TestContext *ctx) {
         loud_buf[i * 2 + 1] = 12000;
     }
 
+    // Two updates fill the 2048-sample FFT analysis ring.
+    viz_update_levels(loud_buf, 1024);
     viz_update_levels(loud_buf, 1024);
     for (int i = 0; i < cfg.viz_bands; i++) {
         if (viz_levels[i] > 0.0f || viz_peaks[i] > 0.0f || viz_peak_timers[i] > 0) {

--- a/tests/core_harness.c
+++ b/tests/core_harness.c
@@ -1001,7 +1001,6 @@ static bool test_config_layout_smoke(TestContext *ctx) {
     char path[MAX_PATH_LEN];
 
     prepare_test();
-    set_env_option("media_responsive", "Off");
     set_env_option("media_show_art", "Off");
     set_env_option("media_viz_mode", "Line");
     set_env_option("media_viz_bands", "20");
@@ -1014,8 +1013,6 @@ static bool test_config_layout_smoke(TestContext *ctx) {
 
     run_frames(6);
 
-    if (!require_true(cfg.responsive == false, "config_layout_smoke: expected responsive layout to be off"))
-        return false;
     if (!require_true(cfg.viz_mode == VIZ_MODE_LINE, "config_layout_smoke: expected line visualizer mode"))
         return false;
     if (!require_true(cfg.viz_bands == 20, "config_layout_smoke: expected 20 visualizer bands"))
@@ -1039,7 +1036,6 @@ static bool test_vu_mode_updates_once_per_frame(TestContext *ctx) {
     int right_timer_before_draw = 0;
 
     prepare_test();
-    set_env_option("media_responsive", "Off");
     set_env_option("media_show_art", "Off");
     set_env_option("media_viz_mode", "VU Meter");
     set_env_option("media_viz_peak_hold", "3");
@@ -1119,7 +1115,6 @@ static bool test_track_change_resets_fft_visualizer_state(TestContext *ctx) {
     bool saw_level = false;
 
     prepare_test();
-    set_env_option("media_responsive", "Off");
     set_env_option("media_show_art", "Off");
     set_env_option("media_viz_mode", "Bars");
     set_env_option("media_viz_bands", "20");

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -289,6 +289,7 @@ def build_harness(repo_root: Path, temp_dir: Path, compiler: str) -> Path:
         "src/image_codecs.c",
         "src/config.c",
         "src/layout.c",
+        "src/ui.c",
     ]
     extra_cflags = split_cflags(os.environ.get("CFLAGS", ""))
     command = [


### PR DESCRIPTION
## Summary

A ground-up revamp of the core's entire presentation layer, built and smoke-tested in EmuVR throughout.

**The deck UI.** Drawing moved out of `core.c` into a new `ui.c` built on new `video.c` primitives (filled rects, bevels, RGB565 blending, ordered dithering, integer-scaled text). The screen is now a hardware-style deck: dithered background gradient, album art in a beveled frame with drop shadow, a sunken visualizer panel, a 2x marquee title (scrolls only on overflow, holds at each end), a bordered progress bar with elapsed + total time, and pixel transport icons with a track counter. All chrome colors derive from the user's bg/fg pair. The legacy non-responsive path (`media_responsive` + six `media_*_y` offsets) was removed; the layout degrades in a fixed priority on short screens (transport auto-hides first, then title scale, then visualizer height).

**Visualizers.** Bars render as an LED segment ladder; the VU meter gained true per-channel RMS on a -40..0 dB sweep with ~150ms ballistics and a meter face (and a fix for a bug that made its stereo layout unreachable); Dots drag phosphor trails; Line connects steep slopes; the FFT doubled to 2048 points for real bass resolution. Three new modes join the X cycle: **Scope** (zero-crossing-triggered min/max envelope oscilloscope with afterglow), **Mirror** (Kenwood-style mirrored spectrum with outward shear, reflection, and a bass-pulsing crest), and **Horizon** (a 3D spectrum landscape receding into fog, software-rendered).

**Infrastructure.** Animations pace in real time via the frame-time callback (correct on non-60Hz hosts), and a `media_resolution` option renders the same logical 320x240 composition at integer scales up to 1280x960, switching via `SET_GEOMETRY` within a pre-declared max (never `SET_SYSTEM_AV_INFO`, whose driver reinit can tear down EmuVR's shared-texture pipeline).

## Review coverage

- Four parallel verification agents audited every core option end-to-end after the legacy-path removal (two real bugs found and fixed: the VU mono-lock and a visualizer height underflow).
- Two external review rounds were triaged and applied (gradient-input UB, Mirror band truncation, `SET_GEOMETRY` call-site contract, an unserialize resolution desync, and several cosmetic edge cases).

## Testing

- [x] Native test harness green (23/23) after every commit on the branch (`python3 tests/run_tests.py`)
- [x] Windows DLL built via `scripts/build-windows.ps1`
- [x] Smoke-tested in EmuVR across visualizer modes and all four resolution presets
- [x] CLAUDE.md / CONTRIBUTING.md / README / PR template kept in sync (build commands include `src/ui.c`; constraints updated to the logical-320x240-x-scale model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)